### PR TITLE
 Master - ITSMChangeManagement - Selenium tests part 6

### DIFF
--- a/ITSMChangeManagement.sopm
+++ b/ITSMChangeManagement.sopm
@@ -204,6 +204,12 @@
         <File Permission="644" Location="scripts/test/ITSMStateMachine.t"/>
         <File Permission="644" Location="scripts/test/ITSMTemplate.t"/>
         <File Permission="644" Location="scripts/test/ITSMWorkOrder.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMChangeDelete.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMChangeReset.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMWorkOrderHistoryZoom.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMWorkOrderTemplate.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMWorkOrderZoom.t"/>
         <File Permission="644" Location="var/cron/itsmchange_check.dist"/>
         <File Permission="644" Location="var/httpd/htdocs/js/ITSM.Agent.ChangeManagement.Search.js"/>
         <File Permission="644" Location="var/httpd/htdocs/js/ITSM.Agent.ChangeManagement.WorkorderGraph.js"/>

--- a/scripts/test/Selenium/Agent/AgentITSMChangeDelete.t
+++ b/scripts/test/Selenium/Agent/AgentITSMChangeDelete.t
@@ -81,8 +81,7 @@ $Selenium->RunTest(
             Description   => "Test Description",
             Justification => "Test Justification",
             ChangeStateID => $ChangeStateDataRef->{ItemID},
-            ,
-            UserID => 1,
+            UserID        => 1,
         );
         $Self->True(
             $ChangeID,

--- a/scripts/test/Selenium/Agent/AgentITSMChangeDelete.t
+++ b/scripts/test/Selenium/Agent/AgentITSMChangeDelete.t
@@ -1,0 +1,147 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # get change delete menu module default sysconfig
+        my %ChangeDeleteMenu = $SysConfigObject->ConfigItemGet(
+            Name    => 'ITSMChange::Frontend::MenuModule###100-ChangeDelete',
+            Default => 1,
+        );
+
+        # set change delete menu module to valid
+        my %ChangeDeleteMenuUpdate = map { $_->{Key} => $_->{Content} }
+            grep { defined $_->{Key} } @{ $ChangeDeleteMenu{Setting}->[1]->{Hash}->[1]->{Item} };
+
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'ITSMChange::Frontend::MenuModule###100-ChangeDelete',
+            Value => \%ChangeDeleteMenuUpdate,
+        );
+
+        # get AgentITSMChangeDelete frontend module sysconfig
+        my %ChangeDeleteFrontendUpdate = (
+            'Description' => 'Delete a change',
+            'GroupRo'     => [
+                'itsm-change-manager'
+            ],
+            'NavBarName' => 'ITSM Change',
+            'Title'      => 'Delete'
+        );
+
+        # set AgentITSMChangeDelete frontend module on valid
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Frontend::Module###AgentITSMChangeDelete',
+            Value => \%ChangeDeleteFrontendUpdate,
+        );
+
+        # get general catalog object
+        my $GeneralCatalogObject = $Kernel::OM->Get('Kernel::System::GeneralCatalog');
+
+        # get change state data
+        my $ChangeStateDataRef = $GeneralCatalogObject->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            ,
+            UserID => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMChange screen with requested filter and ordered down
+        $Selenium->get(
+            "${ScriptAlias}index.pl?Action=AgentITSMChange;SortBy=ChangeNumber;OrderBy=Down;View=;Filter=requested"
+        );
+
+        # verify that test created change is present
+        $Self->True(
+            index( $Selenium->get_page_source(), $ChangeTitleRandom ) > -1,
+            "$ChangeTitleRandom - found",
+        );
+
+        # click on test created change
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeZoom;ChangeID=$ChangeID')]")->click();
+
+        # click on 'Delete'
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeDelete;ChangeID=$ChangeID')]")->click();
+
+        # verify delete message and confirm action
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Do you really want to delete this change?' ) > -1,
+            "'Do you really want to delete this change?' - found",
+        );
+        $Selenium->find_element( "#DialogButton1", 'css' )->click();
+
+        # navigate to AgentITSMChange screen with requested filter and ordered down
+        $Selenium->get(
+            "${ScriptAlias}index.pl?Action=AgentITSMChange;SortBy=ChangeNumber;OrderBy=Down;View=;Filter=requested"
+        );
+
+        # verify that test created change is deleted
+        $Self->True(
+            index( $Selenium->get_page_source(), $ChangeTitleRandom ) == -1,
+            "$ChangeTitleRandom - not found",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMChangeReset.t
+++ b/scripts/test/Selenium/Agent/AgentITSMChangeReset.t
@@ -1,0 +1,195 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # get change delete menu module default sysconfig
+        my %ChangeResetMenu = $SysConfigObject->ConfigItemGet(
+            Name    => 'ITSMChange::Frontend::MenuModule###110-ChangeReset',
+            Default => 1,
+        );
+
+        # set change delete menu module to valid
+        my %ChangeResetMenuUpdate = map { $_->{Key} => $_->{Content} }
+            grep { defined $_->{Key} } @{ $ChangeResetMenu{Setting}->[1]->{Hash}->[1]->{Item} };
+
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'ITSMChange::Frontend::MenuModule###110-ChangeReset',
+            Value => \%ChangeResetMenuUpdate,
+        );
+
+        # get AgemtITSMChangeReset frontend module sysconfig
+        my %ChangeResetFrontendUpdate = (
+            'Description' => 'Reset a change and its workorders',
+            'GroupRo'     => [
+                'itsm-change-builder'
+            ],
+            'NavBarName' => 'ITSM Change',
+            'Title'      => 'Reset'
+        );
+
+        # set AgemtITSMChangeReset frontend module on valid
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Frontend::Module###AgentITSMChangeReset',
+            Value => \%ChangeResetFrontendUpdate,
+        );
+
+        # get general catalog object
+        my $GeneralCatalogObject = $Kernel::OM->Get('Kernel::System::GeneralCatalog');
+
+        # get change state datas
+        my @ChangeStateIDs;
+        for my $ChangeState (qw(requested approved)) {
+            my $ChangeStateDataRef = $GeneralCatalogObject->ItemGet(
+                Class => 'ITSM::ChangeManagement::Change::State',
+                Name  => $ChangeState,
+            );
+            push @ChangeStateIDs, $ChangeStateDataRef->{ItemID};
+        }
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Approved ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateIDs[1],
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order state datas
+        my @WorkOrderStateIDs;
+        for my $WorkOrderState (qw(Created Accepted)) {
+            my $WorkOrderStateDataRef = $GeneralCatalogObject->ItemGet(
+                Class => 'ITSM::ChangeManagement::WorkOrder::State',
+                Name  => $WorkOrderState,
+            );
+            push @WorkOrderStateIDs, $WorkOrderStateDataRef->{ItemID};
+        }
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID         => $ChangeID,
+            WorkOrderTitle   => $WorkOrderTitleRandom,
+            Instruction      => 'Selenium Test Work Order',
+            WorkOrderStateID => $WorkOrderStateIDs[1],
+            PlannedEffort    => 10,
+            UserID           => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMChangeZoom of created test change
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMChangeZoom;ChangeID=$ChangeID");
+
+        # click on 'Reset'
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeReset;ChangeID=$ChangeID')]")->click();
+
+        # verify delete message and confirm action
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Do you really want to reset this change?' ) > -1,
+            "'Do you really want to reset this change?' - found",
+        );
+        $Selenium->find_element( "#DialogButton1", 'css' )->click();
+
+        # click on 'History' and switch window
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeHistory;ChangeID=$ChangeID')]")->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # verify that change state is reseted
+        my $WorkOrderResetMessage
+            = "(ID=\"$WorkOrderID\", \"Workorder State\", \"Created (ID=$WorkOrderStateIDs[0])\", \"Accepted (ID=$WorkOrderStateIDs[1]))";
+        my $ChangeResetMessage
+            = "Change State\", \"Requested (ID=$ChangeStateIDs[0])\", \"Approved (ID=$ChangeStateIDs[1])";
+        $Self->True(
+            index( $Selenium->get_page_source(), $WorkOrderResetMessage ) > -1,
+            "$WorkOrderResetMessage - found",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), $ChangeResetMessage ) > -1,
+            "$ChangeResetMessage - found",
+        );
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderHistoryZoom.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderHistoryZoom.t
@@ -1,0 +1,132 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            ,
+            UserID => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-manager' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom for test created work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # click on 'History' and switch window
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMWorkOrderHistory;WorkOrderID=$WorkOrderID')]")
+            ->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # click on history show details to check AgentITSMWorkOrderHistoryZoom screen
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMWorkOrderHistoryZoom;HistoryEntryID=' )]")
+            ->click();
+
+        # check AgentITSMWorkOrderHistoryZoom values
+        $Self->True(
+            index( $Selenium->get_page_source(), "Detailed history information of WorkOrderUpdate" ) > -1,
+            "Detailed history information of WorkOrderUpdate - found",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), "WorkOrderTitle" ) > -1,
+            "WorkOrderTitle - found",
+        );
+        $Self->True(
+            index( $Selenium->get_page_source(), $WorkOrderTitleRandom ) > -1,
+            "$WorkOrderTitleRandom - found",
+        );
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderHistoryZoom.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderHistoryZoom.t
@@ -37,8 +37,7 @@ $Selenium->RunTest(
             Description   => "Test Description",
             Justification => "Test Justification",
             ChangeStateID => $ChangeStateDataRef->{ItemID},
-            ,
-            UserID => 1,
+            UserID        => 1,
         );
         $Self->True(
             $ChangeID,

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
@@ -1,0 +1,170 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # do not check RichText
+        $Kernel::OM->Get('Kernel::System::SysConfig')->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'Frontend::RichText',
+            Value => 0
+        );
+
+        # get general catalog object
+        my $GeneralCatalogObject = $Kernel::OM->Get('Kernel::System::GeneralCatalog');
+
+        # get change state data
+        my $ChangeStateDataRef = $GeneralCatalogObject->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            ,
+            UserID => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-manager' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom for test created work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # get work order states
+        my @WorkOrderStates = ( 'Accepted', 'Ready', 'In Progress', 'closed' );
+
+        for my $WorkOrderState (@WorkOrderStates) {
+
+            # click on 'Report' and switch window
+            $Selenium->find_element(
+                "//a[contains(\@href, \'Action=AgentITSMWorkOrderReport;WorkOrderID=$WorkOrderID')]"
+            )->click();
+
+            my $Handles = $Selenium->get_window_handles();
+            $Selenium->switch_to_window( $Handles->[1] );
+
+            # get work order state data
+            my $WorkOrderStateDataRef = $GeneralCatalogObject->ItemGet(
+                Class => 'ITSM::ChangeManagement::WorkOrder::State',
+                Name  => $WorkOrderState,
+            );
+
+            # input text in report and select next work order state
+            $Selenium->find_element( "#RichText", 'css' )->send_keys(" $WorkOrderState");
+            $Selenium->find_element( "#WorkOrderStateID option[value='$WorkOrderStateDataRef->{ItemID}']", 'css' )
+                ->click();
+
+            # submit and switch back window
+            $Selenium->find_element( "#SubmitWorkOrderEditReport", 'css' )->click();
+            $Selenium->switch_to_window( $Handles->[0] );
+
+            # click on 'History' and switch window
+            $Selenium->find_element(
+                "//a[contains(\@href, \'Action=AgentITSMWorkOrderHistory;WorkOrderID=$WorkOrderID')]"
+            )->click();
+
+            $Handles = $Selenium->get_window_handles();
+            $Selenium->switch_to_window( $Handles->[1] );
+
+            # verify report change
+            my $ReportUpdateMessage = "\"Workorder State\", \"$WorkOrderState (ID=$WorkOrderStateDataRef->{ItemID})\"";
+            $Self->True(
+                index( $Selenium->get_page_source(), $ReportUpdateMessage ) > -1,
+                "$ReportUpdateMessage - found",
+            );
+
+            # close history pop up and switch window
+            $Selenium->find_element( ".CancelClosePopup", 'css' )->click();
+            $Selenium->switch_to_window( $Handles->[0] );
+        }
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
@@ -52,8 +52,7 @@ $Selenium->RunTest(
             Description   => "Test Description",
             Justification => "Test Justification",
             ChangeStateID => $ChangeStateDataRef->{ItemID},
-            ,
-            UserID => 1,
+            UserID        => 1,
         );
         $Self->True(
             $ChangeID,

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderTemplate.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderTemplate.t
@@ -1,0 +1,162 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            ,
+            UserID => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderInstruction = 'Selenium Test Work Order';
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => $WorkOrderInstruction,
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-manager' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom for test created work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # click on 'Template' and switch window
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMWorkOrderTemplate;WorkOrderID=$WorkOrderID')]")
+            ->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # check page
+        for my $ID (qw(TemplateName Comment StateReset ValidID SubmitAddTemplate))
+        {
+            my $Element = $Selenium->find_element( "#$ID", 'css' );
+            $Element->is_enabled();
+            $Element->is_displayed();
+        }
+
+        # create test template from test work order
+        my $TemplateNameRandom = "Work Order Template " . $Helper->GetRandomID();
+        $Selenium->find_element( "#TemplateName",      'css' )->send_keys($TemplateNameRandom);
+        $Selenium->find_element( "#Comment",           'css' )->send_keys("SeleniumComment");
+        $Selenium->find_element( "#SubmitAddTemplate", 'css' )->click();
+
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # navigate to ITSMChangeTemplateOverview screen
+        $Selenium->get(
+            "${ScriptAlias}index.pl?Action=AgentITSMTemplateOverview;SortBy=TemplateID;OrderBy=Up;Filter=ITSMWorkOrder"
+        );
+
+        # check for test created work order termplate
+        $Self->True(
+            index( $Selenium->get_page_source(), $TemplateNameRandom ) > -1,
+            "$TemplateNameRandom - found",
+        );
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete created test change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # get DB object
+        my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
+
+        # get test change template ID
+        my $TemplatedQuoted = $DBObject->Quote($TemplateNameRandom);
+        $DBObject->Prepare(
+            SQL  => "SELECT id FROM change_template WHERE name = ?",
+            Bind => [ \$TemplatedQuoted ]
+        );
+        my $TemplateID;
+        while ( my @Row = $DBObject->FetchrowArray() ) {
+            $TemplateID = $Row[0];
+        }
+
+        # delete created test template
+        $Success = $Kernel::OM->Get('Kernel::System::ITSMChange::Template')->TemplateDelete(
+            TemplateID => $TemplateID,
+            UserID     => 1,
+        );
+
+        # make sure the cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderTemplate.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderTemplate.t
@@ -37,8 +37,7 @@ $Selenium->RunTest(
             Description   => "Test Description",
             Justification => "Test Justification",
             ChangeStateID => $ChangeStateDataRef->{ItemID},
-            ,
-            UserID => 1,
+            UserID        => 1,
         );
         $Self->True(
             $ChangeID,

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderZoom.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderZoom.t
@@ -37,8 +37,7 @@ $Selenium->RunTest(
             Description   => "Test Description",
             Justification => "Test Justification",
             ChangeStateID => $ChangeStateDataRef->{ItemID},
-            ,
-            UserID => 1,
+            UserID        => 1,
         );
         $Self->True(
             $ChangeID,

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderZoom.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderZoom.t
@@ -1,0 +1,124 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => "Test Description",
+            Justification => "Test Justification",
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            ,
+            UserID => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-manager' ],
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom for test created work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # verify its right screen
+        $Self->True(
+            index( $Selenium->get_page_source(), $WorkOrderTitleRandom ) > -1,
+            "$WorkOrderTitleRandom found on page",
+        );
+
+        # check page
+        for my $Action (
+            qw( WorkOrderHistory ChangePrint WorkOrderEdit WorkOrderAgent WorkOrderReport WorkOrderTemplate WorkOrderDelete)
+            )
+        {
+            my $Element
+                = $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSM$Action;WorkOrderID=$WorkOrderID')]");
+            $Element->is_enabled();
+            $Element->is_displayed();
+        }
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete created test change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure the cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;


### PR DESCRIPTION
Hi @UdoBretz ,

Here are selenium test for following modules:

AgentITSMChangeDelete
AgentITSMChangeReset
AgentITSMWorkOrderHistoryZoom
AgentITSMWorkOrderReport
AgentITSMWorkOrderTemplate
AgentITSMWorkOrderZoom

During testing of AgentITSMChange Delete and Reset modules, it came to mine attention that these modules are not enabled as frontend modules in SysConfig by default. Not sure if this is intentional or not, but considered it is something worth pointing out. If there are questions regarding this, let me know.

Regards,
Sanjin