### PR TITLE
Master - ITSMChangeManagement - Selenium tests part 8

### DIFF
--- a/ITSMChangeManagement.sopm
+++ b/ITSMChangeManagement.sopm
@@ -204,6 +204,16 @@
         <File Permission="644" Location="scripts/test/ITSMStateMachine.t"/>
         <File Permission="644" Location="scripts/test/ITSMTemplate.t"/>
         <File Permission="644" Location="scripts/test/ITSMWorkOrder.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMChangeConditionEdit.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Agent/AgentITSMWorkOrderTake.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ITSMChange/MenuGeneric.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ITSMWorkOrder/MenuGeneric.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/LinkObject/ITSMChange.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/LinkObject/ITSMWorkOrder.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ToolBar/ChangeManager.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ToolBar/MyCAB.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ToolBar/MyChanges.t"/>
+        <File Permission="644" Location="scripts/test/Selenium/Output/ToolBar/MyWorkOrder.t"/>
         <File Permission="644" Location="var/cron/itsmchange_check.dist"/>
         <File Permission="644" Location="var/httpd/htdocs/js/ITSM.Agent.ChangeManagement.Search.js"/>
         <File Permission="644" Location="var/httpd/htdocs/js/ITSM.Agent.ChangeManagement.WorkorderGraph.js"/>

--- a/Kernel/Modules/AgentITSMWorkOrderTake.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderTake.pm
@@ -107,7 +107,7 @@ sub Run {
     # Login name of the current workorder agent
     my $WorkOrderAgent = '-';
     if ( $WorkOrder->{WorkOrderAgentID} ) {
-        $WorkOrderAgent = $Self->{UserObject}->UserLookup(
+        $WorkOrderAgent = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
             UserID => $WorkOrder->{WorkOrderAgentID},
         );
     }

--- a/scripts/test/Selenium/Agent/AgentITSMChangeConditionEdit.t
+++ b/scripts/test/Selenium/Agent/AgentITSMChangeConditionEdit.t
@@ -1,0 +1,147 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMChangeZoom of created test change
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMChangeZoom;ChangeID=$ChangeID");
+
+        # click on 'Conditions' and switch screens
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeCondition;ChangeID=$ChangeID' )]")
+            ->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # click 'Add new condition'
+        $Selenium->find_element("//button[\@name='AddCondition'][\@type='submit']")->click();
+
+        # create test condition
+        my $ConditionNameRandom = "Condition " . $Helper->GetRandomID();
+        $Selenium->find_element( "#Name",    'css' )->send_keys($ConditionNameRandom);
+        $Selenium->find_element( "#Comment", 'css' )->send_keys("SeleniumCondition");
+
+        # get condition object
+        my $ConditionObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMCondition');
+
+        # get needed IDs
+        my $ExpresionAttributeID = $ConditionObject->AttributeLookup(
+            Name => 'PriorityID',
+        );
+        my $PriorityDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Priority',
+            Name  => '2 low',
+        );
+        my $ActionAttributeID = $ConditionObject->AttributeLookup(
+            Name => 'ChangeStateID'
+        );
+        my $ActionOperatorID = $ConditionObject->OperatorLookup(
+            Name => 'set',
+        );
+        my $ConditionChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'approved',
+        );
+
+        # add new expresion
+        # in change object for test change, look for priority value of '2 low'
+        $Selenium->find_element("//button[\@name='AddExpression'][\@type='submit']")->click();
+        $Selenium->find_element( "#ExpressionID-NEW-ObjectID option[value='1']",         'css' )->click();
+        $Selenium->find_element( "#ExpressionID-NEW-Selector option[value='$ChangeID']", 'css' )->click();
+        $Selenium->find_element( "#ExpressionID-NEW-AttributeID option[value='$ExpresionAttributeID']", 'css' )
+            ->click();
+        $Selenium->find_element( "#ExpressionID-NEW-OperatorID option[value='1']", 'css' )->click();
+        $Selenium->find_element( "#ExpressionID-NEW-CompareValue option[value='$PriorityDataRef->{ItemID}']", 'css' )
+            ->click();
+
+        # add new action
+        # in change object for test change, set change state on 'Approved'
+        $Selenium->find_element("//button[\@name='AddAction'][\@type='submit']")->click();
+        $Selenium->find_element( "#ActionID-NEW-ObjectID option[value='1']",                     'css' )->click();
+        $Selenium->find_element( "#ActionID-NEW-Selector option[value='$ChangeID']",             'css' )->click();
+        $Selenium->find_element( "#ActionID-NEW-AttributeID option[value='$ActionAttributeID']", 'css' )->click();
+        $Selenium->find_element( "#ActionID-NEW-OperatorID option[value='$ActionOperatorID']",   'css' )->click();
+        $Selenium->find_element(
+            "#ActionID-NEW-ActionValue option[value='$ConditionChangeStateDataRef->{ItemID}']",
+            'css'
+        )->click();
+
+        $Selenium->find_element("//button[\@value='Submit'][\@type='submit']")->click();
+
+        # verify created condition name value
+        $Self->True(
+            index( $Selenium->get_page_source(), $ConditionNameRandom ) > -1,
+            "$ConditionNameRandom - found",
+        );
+
+        # delete test created change
+        my $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderTake.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderTake.t
@@ -1,0 +1,171 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        $Kernel::OM->ObjectParamAdd(
+            'Kernel::System::UnitTest::Helper' => {
+                RestoreSystemConfiguration => 1,
+            },
+        );
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get sysconfig object
+        my $SysConfigObject = $Kernel::OM->Get('Kernel::System::SysConfig');
+
+        # get work order empty agent default sysconfig
+        my %WorkOrderEmptyAgent = $SysConfigObject->ConfigItemGet(
+            Name    => 'ITSMWorkOrder::TakePermission###10-EmptyAgent',
+            Default => 1,
+        );
+
+        # set work order empty agent to valid
+        my %WorkOrderEmptyAgentUpdate = map { $_->{Key} => $_->{Content} }
+            grep { defined $_->{Key} } @{ $WorkOrderEmptyAgent{Setting}->[1]->{Hash}->[1]->{Item} };
+
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'ITSMWorkOrder::TakePermission###10-EmptyAgent',
+            Value => \%WorkOrderEmptyAgentUpdate,
+        );
+
+        # get work order list agent default sysconfig
+        my %WorkOrderListAgent = $SysConfigObject->ConfigItemGet(
+            Name    => 'ITSMWorkOrder::TakePermission###20-ListAgent',
+            Default => 1,
+        );
+
+        # set work order list agent to valid
+        my %WorkOrderListAgentUpdate = map { $_->{Key} => $_->{Content} }
+            grep { defined $_->{Key} } @{ $WorkOrderListAgent{Setting}->[1]->{Hash}->[1]->{Item} };
+
+        $SysConfigObject->ConfigItemUpdate(
+            Valid => 1,
+            Key   => 'ITSMWorkOrder::TakePermission###20-ListAgent',
+            Value => \%WorkOrderListAgentUpdate,
+        );
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom for test created work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # click on 'Take Workorder'
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMWorkOrderTake;WorkOrderID=$WorkOrderID')]")
+            ->click();
+
+        # verify take work order message and confirm action
+        $Self->True(
+            index( $Selenium->get_page_source(), 'Do you really want to take this workorder?' ) > -1,
+            "'Do you really want to take this workorder?' - found",
+        );
+        $Selenium->find_element( "#DialogButton1", 'css' )->click();
+
+        # click on 'History' and switch window
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMWorkOrderHistory;WorkOrderID=$WorkOrderID' )]")
+            ->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # check for take work order history message
+        my $ExpectedTakeWorkOrderMessage = "WorkOrderHistory::WorkOrderUpdate\", \"Workorder Agent\", \"$TestUserLogin";
+        $Self->True(
+            index( $Selenium->get_page_source(), $ExpectedTakeWorkOrderMessage ) > -1,
+            "$ExpectedTakeWorkOrderMessage - found",
+        );
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ITSMChange/MenuGeneric.t
+++ b/scripts/test/Selenium/Output/ITSMChange/MenuGeneric.t
@@ -1,0 +1,162 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMChangeZoom of created test change
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMChangeZoom;ChangeID=$ChangeID");
+
+        # create menu module test params
+        my @MenuModule = (
+            {
+                Name   => "Back",
+                Action => "AgentITSMChange",
+            },
+            {
+                Name   => "History",
+                Action => "AgentITSMChangeHistory",
+            },
+            {
+                Name   => "Print",
+                Action => "AgentITSMChangePrint",
+            },
+            {
+                Name   => "Edit",
+                Action => "AgentITSMChangeEdit",
+            },
+            {
+                Name   => "Involved Persons",
+                Action => "AgentITSMChangeInvolvedPersons",
+            },
+            {
+                Name   => "Add Workorder",
+                Action => "AgentITSMWorkOrderAdd",
+            },
+            {
+                Name   => "Add Workorder (from template)",
+                Action => "AgentITSMWorkOrderAddFromTemplate",
+            },
+            {
+                Name   => "Condition",
+                Action => "AgentITSMChangeCondition",
+            },
+            {
+                Name   => "Link",
+                Action => "AgentLinkObject",
+            },
+            {
+                Name   => "Move Time Slot",
+                Action => "AgentITSMChangeTimeSlot",
+            },
+            {
+                Name   => "Template",
+                Action => "AgentITSMChangeTemplate",
+            },
+        );
+
+        # check change menu modules
+        for my $ChangeZoomMenuModule (@MenuModule) {
+            $Self->True(
+                $Selenium->find_element("//a[contains(\@href, \'Action=$ChangeZoomMenuModule->{Action}' )]"),
+                "Change menu $ChangeZoomMenuModule->{Name} - found"
+            );
+        }
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ITSMWorkOrder/MenuGeneric.t
+++ b/scripts/test/Selenium/Output/ITSMWorkOrder/MenuGeneric.t
@@ -1,0 +1,154 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom of created test work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # create menu module test params
+        my @MenuModule = (
+            {
+                Name   => "Back",
+                Action => "AgentITSMChangeZoom",
+            },
+            {
+                Name   => "History",
+                Action => "AgentITSMWorkOrderHistory",
+            },
+            {
+                Name   => "Print",
+                Action => "AgentITSMChangePrint",
+            },
+            {
+                Name   => "Edit",
+                Action => "AgentITSMWorkOrderEdit",
+            },
+            {
+                Name   => "Workorder Agent",
+                Action => "AgentITSMWorkOrderAgent",
+            },
+            {
+                Name   => "Report",
+                Action => "AgentITSMWorkOrderReport",
+            },
+            {
+                Name   => "Link",
+                Action => "AgentLinkObject",
+            },
+            {
+                Name   => "Template",
+                Action => "AgentITSMWorkOrderTemplate",
+            },
+            {
+                Name   => "Delete",
+                Action => "AgentITSMWorkOrderDelete",
+            },
+        );
+
+        # check work order menu modules
+        for my $WorkOrderZoomMenuModule (@MenuModule) {
+            $Self->True(
+                $Selenium->find_element("//a[contains(\@href, \'Action=$WorkOrderZoomMenuModule->{Action}' )]"),
+                "Change menu $WorkOrderZoomMenuModule->{Name} - found"
+            );
+        }
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/LinkObject/ITSMChange.t
+++ b/scripts/test/Selenium/Output/LinkObject/ITSMChange.t
@@ -1,0 +1,154 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TicketNumber = $TicketObject->TicketCreateNumber();
+        my $TicketID     = $TicketObject->TicketCreate(
+            TN           => $TicketNumber,
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'open',
+            CustomerID   => 'Test Selenium Customer',
+            CustomerUser => 'Test Selenium Customer',
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "Ticket ID $TicketID - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMChangeZoom of created test change
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMChangeZoom;ChangeID=$ChangeID");
+
+        # click on 'Link' and switch screens
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=ITSMChange' )]")->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # select test created ticket to link with test created change
+        $Selenium->find_element("//input[\@name='SEARCH::TicketNumber']")->send_keys($TicketNumber);
+        $Selenium->find_element("//button[\@value='Search'][\@type='submit']")->click();
+        $Selenium->WaitFor( JavaScript => "return \$('input#LinkTargetKeys').length" );
+
+        $Selenium->find_element("//input[\@id='LinkTargetKeys']")->click();
+        $Selenium->find_element("//button[\@id='AddLinks'][\@type='submit']")->click();
+        $Selenium->find_element( "#LinkAddCloseLink", 'css' )->click();
+
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # verify test change is linked with test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
+            "Test ticket number $TicketNumber - found",
+        );
+
+        # click on 'Link' and switch screens
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=ITSMChange' )]")->click();
+
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # delete link relation
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=LinkDelete' )]")->click();
+        $Selenium->find_element("//input[\@id='LinkDeleteIdentifier']")->click();
+        $Selenium->find_element("//button[\@type='submit']")->click();
+
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;Subaction=Close' )]")->click();
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # verify that link has been removed
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) == -1,
+            "Test ticket number $TicketNumber - found",
+        );
+
+        # delete test created change
+        my $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # delete test created ticket
+        $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket ID $TicketID - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/LinkObject/ITSMWorkOrder.t
+++ b/scripts/test/Selenium/Output/LinkObject/ITSMWorkOrder.t
@@ -1,0 +1,184 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID       => $ChangeID,
+            WorkOrderTitle => $WorkOrderTitleRandom,
+            Instruction    => 'Selenium Test Work Order',
+            PlannedEffort  => 10,
+            UserID         => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # get ticket object
+        my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
+
+        # create test ticket
+        my $TicketNumber = $TicketObject->TicketCreateNumber();
+        my $TicketID     = $TicketObject->TicketCreate(
+            TN           => $TicketNumber,
+            Title        => 'Selenium Test Ticket',
+            Queue        => 'Raw',
+            Lock         => 'unlock',
+            Priority     => '3 normal',
+            State        => 'open',
+            CustomerID   => 'Test Selenium Customer',
+            CustomerUser => 'Test Selenium Customer',
+            OwnerID      => 1,
+            UserID       => 1,
+        );
+        $Self->True(
+            $TicketID,
+            "Ticket ID $TicketID - created",
+        );
+
+        # create and log in test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'users', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # get script alias
+        my $ScriptAlias = $Kernel::OM->Get('Kernel::Config')->Get('ScriptAlias');
+
+        # navigate to AgentITSMWorkOrderZoom of created test work order
+        $Selenium->get("${ScriptAlias}index.pl?Action=AgentITSMWorkOrderZoom;WorkOrderID=$WorkOrderID");
+
+        # click on 'Link' and switch screens
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=ITSMWorkOrder' )]")
+            ->click();
+
+        my $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # select test created ticket to link with test created work order
+        $Selenium->find_element( "#TargetIdentifier option[value='Ticket']", 'css' )->click();
+        $Selenium->find_element("//input[\@name='SEARCH::TicketNumber']")->send_keys($TicketNumber);
+        $Selenium->find_element("//button[\@value='Search'][\@type='submit']")->click();
+        $Selenium->WaitFor( JavaScript => "return \$('input#LinkTargetKeys').length" );
+
+        $Selenium->find_element("//input[\@id='LinkTargetKeys']")->click();
+        $Selenium->find_element("//button[\@id='AddLinks'][\@type='submit']")->click();
+        $Selenium->find_element( "#LinkAddCloseLink", 'css' )->click();
+
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # verify test work order is linked with test ticket
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) > -1,
+            "Test ticket number $TicketNumber - found",
+        );
+
+        # click on 'Link' and switch screens
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;SourceObject=ITSMWorkOrder' )]")
+            ->click();
+
+        $Handles = $Selenium->get_window_handles();
+        $Selenium->switch_to_window( $Handles->[1] );
+
+        # delete link relation
+        $Selenium->find_element("//a[contains(\@href, \'Subaction=LinkDelete' )]")->click();
+        $Selenium->find_element("//input[\@id='LinkDeleteIdentifier']")->click();
+        $Selenium->find_element("//button[\@type='submit']")->click();
+
+        $Selenium->find_element("//a[contains(\@href, \'Action=AgentLinkObject;Subaction=Close' )]")->click();
+        $Selenium->switch_to_window( $Handles->[0] );
+
+        # verify that link has been removed
+        $Self->True(
+            index( $Selenium->get_page_source(), $TicketNumber ) == -1,
+            "Test ticket number $TicketNumber - found",
+        );
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # delete test created ticket
+        $Success = $TicketObject->TicketDelete(
+            TicketID => $TicketID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "Ticket ID $TicketID - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ToolBar/ChangeManager.t
+++ b/scripts/test/Selenium/Output/ToolBar/ChangeManager.t
@@ -1,0 +1,85 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle     => $ChangeTitleRandom,
+            Description     => 'Selenium Test Description',
+            Justification   => 'Seleniun Test Justification',
+            ChangeStateID   => $ChangeStateDataRef->{ItemID},
+            ChangeManagerID => $TestUserID,
+            UserID          => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # log in test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # verify that tool bar ChangeManager is enabled and displayed
+        my $Element = $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeManager')]");
+        $Element->is_enabled();
+        $Element->is_displayed();
+
+        # delete test created change
+        my $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ToolBar/MyCAB.t
+++ b/scripts/test/Selenium/Output/ToolBar/MyCAB.t
@@ -1,0 +1,85 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            CABAgents     => [$TestUserID],
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # log in test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # verify that tool bar MyCAB is enabled and displayed
+        my $Element = $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeMyCAB')]");
+        $Element->is_enabled();
+        $Element->is_displayed();
+
+        # delete test created change
+        my $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ToolBar/MyChanges.t
+++ b/scripts/test/Selenium/Output/ToolBar/MyChanges.t
@@ -1,0 +1,84 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => $TestUserID,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # log in test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # verify that tool bar MyChanges is enabled and displayed
+        my $Element = $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeMyChanges')]");
+        $Element->is_enabled();
+        $Element->is_displayed();
+
+        # delete test created change
+        my $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;

--- a/scripts/test/Selenium/Output/ToolBar/MyWorkOrder.t
+++ b/scripts/test/Selenium/Output/ToolBar/MyWorkOrder.t
@@ -1,0 +1,112 @@
+# --
+# Copyright (C) 2001-2015 OTRS AG, http://otrs.com/
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+use strict;
+use warnings;
+use utf8;
+
+use vars (qw($Self));
+
+# get selenium object
+my $Selenium = $Kernel::OM->Get('Kernel::System::UnitTest::Selenium');
+
+$Selenium->RunTest(
+    sub {
+
+        # get helper object
+        my $Helper = $Kernel::OM->Get('Kernel::System::UnitTest::Helper');
+
+        # create test user
+        my $TestUserLogin = $Helper->TestUserCreate(
+            Groups => [ 'admin', 'itsm-change', 'itsm-change-builder', 'itsm-change-manager' ]
+        ) || die "Did not get test user";
+
+        # get test user ID
+        my $TestUserID = $Kernel::OM->Get('Kernel::System::User')->UserLookup(
+            UserLogin => $TestUserLogin,
+        );
+
+        # get change state data
+        my $ChangeStateDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
+            Class => 'ITSM::ChangeManagement::Change::State',
+            Name  => 'requested',
+        );
+
+        # get change object
+        my $ChangeObject = $Kernel::OM->Get('Kernel::System::ITSMChange');
+
+        # create test change
+        my $ChangeTitleRandom = 'ITSMChange Requested ' . $Helper->GetRandomID();
+        my $ChangeID          = $ChangeObject->ChangeAdd(
+            ChangeTitle   => $ChangeTitleRandom,
+            Description   => 'Selenium Test Description',
+            Justification => 'Seleniun Test Justification',
+            ChangeStateID => $ChangeStateDataRef->{ItemID},
+            UserID        => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$ChangeTitleRandom - created",
+        );
+
+        # get work order object
+        my $WorkOrderObject = $Kernel::OM->Get('Kernel::System::ITSMChange::ITSMWorkOrder');
+
+        # create test work order
+        my $WorkOrderTitleRandom = 'Selenium Work Order ' . $Helper->GetRandomID();
+        my $WorkOrderID          = $WorkOrderObject->WorkOrderAdd(
+            ChangeID         => $ChangeID,
+            WorkOrderTitle   => $WorkOrderTitleRandom,
+            Instruction      => 'Selenium Test Work Order',
+            PlannedEffort    => 10,
+            WorkOrderAgentID => $TestUserID,
+            UserID           => 1,
+        );
+        $Self->True(
+            $ChangeID,
+            "$WorkOrderTitleRandom - created",
+        );
+
+        # log in test user
+        $Selenium->Login(
+            Type     => 'Agent',
+            User     => $TestUserLogin,
+            Password => $TestUserLogin,
+        );
+
+        # verify that tool bar MyWorkOrder is enabled and displayed
+        my $Element = $Selenium->find_element("//a[contains(\@href, \'Action=AgentITSMChangeMyWorkOrder')]");
+        $Element->is_enabled();
+        $Element->is_displayed();
+
+        # delete test created work order
+        my $Success = $WorkOrderObject->WorkOrderDelete(
+            WorkOrderID => $WorkOrderID,
+            UserID      => 1,
+        );
+        $Self->True(
+            $Success,
+            "$WorkOrderTitleRandom - deleted",
+        );
+
+        # delete test created change
+        $Success = $ChangeObject->ChangeDelete(
+            ChangeID => $ChangeID,
+            UserID   => 1,
+        );
+        $Self->True(
+            $Success,
+            "$ChangeTitleRandom - deleted",
+        );
+
+        # make sure cache is correct
+        $Kernel::OM->Get('Kernel::System::Cache')->CleanUp( Type => 'ITSMChange*' );
+    }
+);
+
+1;


### PR DESCRIPTION
Hi @UdoBretz  ,

Here are selenium test for following modules:

AgentITSMChangeConditionEdit
AgentITSMWorkOrderTake

Output/ITSMChange/MenuGeneric
Output/ITSMWorkOrder/MenuGeneric
Output/LinkObject/ITSMChange
Output/LinkObject/ITSMWorkOrder
Output/ToolBar/ChangeManager
Output/ToolBar/MyCAB
Output/ToolBar/MyChanges
Output/ToolBar/MyWorkOrder

One note on this PR. During testing of AgentITSMWorkOrderTake, found out that there was mistake during porting to OM, at line 110 there was left $Self->{UserObject}. It is corrected now and module works as expected. 

With this PR, Selenium testings are concluded for ITSMChange modules. There are only left AgentITSMChangeNotification and AgentITSMChangePrint modules to be tested out. Notification test will be added on, once module is functioning and ready for use.

If there are any questions regarding this PR or any others, please do not hesitate to ask.

Regards,
Sanjin
