### PR TITLE
Fixed bug #11747: "All" filter in PIR overview

### DIFF
--- a/Kernel/Modules/AgentITSMChangePIR.pm
+++ b/Kernel/Modules/AgentITSMChangePIR.pm
@@ -178,12 +178,15 @@ sub Run {
         $Self->{Filter} = $FilterName;
     }
     else {
+        # limit to configured states
+        my @WorkOrderStates = keys %Filters;
 
         # add default filter
         $Filters{All} = {
             Name   => 'All',
             Prio   => 1000,
             Search => {
+                WorkOrderStates  => \@WorkOrderStates,
                 WorkOrderTypes   => \@WorkOrderTypes,
                 OrderBy          => \@SortByArray,
                 OrderByDirection => \@OrderByArray,


### PR DESCRIPTION
Hi there,

please note the bug report I created:
http://bugs.otrs.org/show_bug.cgi?id=11747

A backport to OTRS 4 would be great.

Greetings,
  Thorsten