### PR TITLE
Master - ITSMChangeManagement - Selenium - Update Test

### DIFF
--- a/scripts/test/Selenium/Agent/AgentITSMUserSearch.t
+++ b/scripts/test/Selenium/Agent/AgentITSMUserSearch.t
@@ -23,7 +23,7 @@ $Selenium->RunTest(
 
         # get change state data
         my $ChangeDataRef = $Kernel::OM->Get('Kernel::System::GeneralCatalog')->ItemGet(
-            Class => 'ITSM::ChangeManagement::Change::State ',
+            Class => 'ITSM::ChangeManagement::Change::State',
             Name  => 'requested',
         );
 

--- a/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
+++ b/scripts/test/Selenium/Agent/AgentITSMWorkOrderReport.t
@@ -113,13 +113,15 @@ $Selenium->RunTest(
             );
 
             # get work order state data
+            my $ItemGetState          = lc $WorkOrderState;
             my $WorkOrderStateDataRef = $GeneralCatalogObject->ItemGet(
                 Class => 'ITSM::ChangeManagement::WorkOrder::State',
-                Name  => $WorkOrderState,
+                Name  => $ItemGetState,
             );
 
             # input text in report and select next work order state
-            $Selenium->find_element( "#RichText", 'css' )->send_keys(" $WorkOrderState");
+            $Selenium->find_element( "#RichText", 'css' )->clear();
+            $Selenium->find_element( "#RichText", 'css' )->send_keys("$WorkOrderState");
             $Selenium->execute_script(
                 "\$('#WorkOrderStateID').val('$WorkOrderStateDataRef->{ItemID}').trigger('redraw.InputField').trigger('change');"
             );


### PR DESCRIPTION
Hello @UdoBretz ,

Hereby is fix for two Selenium tests for ITSMChangeManagement that were crashing on tests servers.

In AgentITSMUserSearch.t there was extra space on the end of string that was causing problem.
In AgentITSMWorkOrderReport.t there was issues with reading ITSMChange states from DB in case sensitive DB's. Added small workaround and they should perform now as expected.

Please let me know if this fixed issues in your tests servers.

Kind Regards,
Sanjin 