### PR TITLE
Added back link for WorkOrderHistoryZoom

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
@@ -13,6 +13,8 @@
             [% Translate("History of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %]-[% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(60) | html %]
         </h1>
         <p>
+            <a href="[% Env("Baselink") %]Action=AgentITSMWorkOrderHistory;ChangeID=[% Data.ChangeID | uri %]">[% Translate("Back") | html %]</a>
+            [% Translate("or") | html %]
             <a class="CancelClosePopup" href="#">[% Translate("Cancel & close") | html %]</a>
         </p>
     </div>


### PR DESCRIPTION
Hi @UdoBretz 
This PR adds a back link to WorkOrderHistoryZoom screen. Similar PR was already merged with https://github.com/OTRS/ITSMChangeManagement/commit/c3e8a818d398aa10da868b0e01b9fd3b80720ada