### PR TITLE
Fixed DatePicker bug in AgentITSMChangeTimeSlot

### DIFF
--- a/Kernel/Modules/AgentITSMChangeTimeSlot.pm
+++ b/Kernel/Modules/AgentITSMChangeTimeSlot.pm
@@ -248,13 +248,13 @@ sub Run {
                 },
                 {
                     Name       => 'MoveTimeDay',
-                    Data       => [ map { sprintf '%02d', $_ } ( 1 .. 31 ) ],
-                    SelectedID => $Day,
+                    Data       => { map { $_ => sprintf '%02d', $_ } ( 1 .. 31 ) },
+                    SelectedID => sprintf '%0x', $Day,
                 },
                 {
                     Name       => 'MoveTimeMonth',
-                    Data       => [ map { sprintf '%02d', $_ } ( 1 .. 12 ) ],
-                    SelectedID => $Month,
+                    Data       => { map { $_ => sprintf '%02d', $_ } ( 1 .. 12 ) },
+                    SelectedID => sprintf '%0x', $Month,
                 },
                 {
                     Name       => 'MoveTimeYear',


### PR DESCRIPTION
Change of 'Planned End Time' in the AgentITSMChangeTimeSlot view is not possible via the DatePicker.

![datepickerbug](https://cloud.githubusercontent.com/assets/3249687/24647494/6c12f56e-1920-11e7-86b5-0bcea2a13be7.gif)

When the date type is changed to the end date, the data for the date are reloaded and set.
When loading, the key for single-digit numbers is always supplemented with a 0 at the beginning.

After loading:

Key => Value
01 => 01
02 => 02


default:

Key => Value
1 => 01
2 => 02