### PR TITLE
Fixed param

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
@@ -13,7 +13,7 @@
             [% Translate("History of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %]-[% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(60) | html %]
         </h1>
         <p>
-            <a href="[% Env("Baselink") %]Action=AgentITSMWorkOrderHistory;ChangeID=[% Data.ChangeID | uri %]">[% Translate("Back") | html %]</a>
+            <a href="[% Env("Baselink") %]Action=AgentITSMWorkOrderHistory;WorkOrderID=[% Data.ChangeID | uri %]">[% Translate("Back") | html %]</a>
             [% Translate("or") | html %]
             <a class="CancelClosePopup" href="#">[% Translate("Cancel & close") | html %]</a>
         </p>


### PR DESCRIPTION
Hi @UdoBretz 
When I added the back link for the Workorder History Zoom, I copied it from Change History Zoom, and I left the param name unchanged. Sorry, it was my fault. This PR fixes the param.