### PR TITLE
Improved wording

### DIFF
--- a/Kernel/Modules/AgentITSMChangeAdd.pm
+++ b/Kernel/Modules/AgentITSMChangeAdd.pm
@@ -156,7 +156,7 @@ sub Run {
                 Message => $LayoutObject->{LanguageObject}->Translate(
                     'Ticket with TicketID %s does not exist!', $GetParam{TicketID}
                 ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -183,7 +183,7 @@ sub Run {
             # show error message
             return $LayoutObject->ErrorScreen(
                 Message => $Message,
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -207,7 +207,7 @@ sub Run {
             # show error message
             return $LayoutObject->ErrorScreen(
                 Message => $Message,
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -303,7 +303,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Could not perform validation on field %s!', $DynamicFieldConfig->{Label}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -408,7 +408,7 @@ sub Run {
                         # show error message
                         return $LayoutObject->ErrorScreen(
                             Message => $Message,
-                            Comment => Translatable('Please contact the admin.'),
+                            Comment => Translatable('Please contact the administrator.'),
                         );
                     }
                 }
@@ -491,7 +491,7 @@ sub Run {
                 # show error message, when adding failed
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to add change!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }

--- a/Kernel/Modules/AgentITSMChangeAddFromTemplate.pm
+++ b/Kernel/Modules/AgentITSMChangeAddFromTemplate.pm
@@ -94,7 +94,7 @@ sub Run {
                 Message => $LayoutObject->{LanguageObject}->Translate(
                     'Ticket with TicketID %s does not exist!', $GetParam{TicketID}
                 ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -121,7 +121,7 @@ sub Run {
             # show error message
             return $LayoutObject->ErrorScreen(
                 Message => $Message,
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -145,7 +145,7 @@ sub Run {
             # show error message
             return $LayoutObject->ErrorScreen(
                 Message => $Message,
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -229,7 +229,7 @@ sub Run {
                 # show error message, when adding failed
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to create change from template!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -263,7 +263,7 @@ sub Run {
                     # show error message
                     return $LayoutObject->ErrorScreen(
                         Message => $Message,
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
             }

--- a/Kernel/Modules/AgentITSMChangeCABTemplate.pm
+++ b/Kernel/Modules/AgentITSMChangeCABTemplate.pm
@@ -41,7 +41,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -79,7 +79,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'No change found for changeID %s.', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -118,7 +118,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'The CAB of change "%s" could not be serialized.', $ChangeID
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -136,7 +136,7 @@ sub Run {
             if ( !$TemplateID ) {
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Could not add the template.'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 

--- a/Kernel/Modules/AgentITSMChangeCondition.pm
+++ b/Kernel/Modules/AgentITSMChangeCondition.pm
@@ -44,7 +44,7 @@ sub Run {
     if ( !$GetParam{ChangeID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -83,7 +83,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $GetParam{ChangeID} ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -125,7 +125,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message =>
                         $LayoutObject->{LanguageObject}->Translate( 'Could not delete ConditionID %s!', $ConditionID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 

--- a/Kernel/Modules/AgentITSMChangeConditionEdit.pm
+++ b/Kernel/Modules/AgentITSMChangeConditionEdit.pm
@@ -50,7 +50,7 @@ sub Run {
         if ( !$GetParam{$Needed} ) {
             $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}->Translate( 'No %s is given!', $Needed ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
             return;
         }
@@ -91,7 +91,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $GetParam{ChangeID} ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -175,7 +175,7 @@ sub Run {
                 if ( !$GetParam{ConditionID} ) {
                     $LayoutObject->ErrorScreen(
                         Message => Translatable('Could not create new condition!'),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                     return;
                 }
@@ -200,7 +200,7 @@ sub Run {
                         Message => $LayoutObject->{LanguageObject}->Translate(
                             'Could not update ConditionID %s!', $GetParam{ConditionID}
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                     return;
                 }
@@ -252,7 +252,7 @@ sub Run {
                             Message => $LayoutObject->{LanguageObject}->Translate(
                                 'Could not update ExpressionID %s!', $ExpressionID
                             ),
-                            Comment => Translatable('Please contact the admin.'),
+                            Comment => Translatable('Please contact the administrator.'),
                         );
                     }
                 }
@@ -299,7 +299,7 @@ sub Run {
                 if ( !$ExpressionID ) {
                     return $LayoutObject->ErrorScreen(
                         Message => Translatable('Could not add new Expression!'),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
             }
@@ -347,7 +347,7 @@ sub Run {
                         return $LayoutObject->ErrorScreen(
                             Message => $LayoutObject->{LanguageObject}
                                 ->Translate( 'Could not update ActionID %s!', $ActionID ),
-                            Comment => Translatable('Please contact the admin.'),
+                            Comment => Translatable('Please contact the administrator.'),
                         );
                     }
                 }
@@ -392,7 +392,7 @@ sub Run {
                 if ( !$ActionID ) {
                     return $LayoutObject->ErrorScreen(
                         Message => Translatable('Could not add new Action!'),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
             }
@@ -439,7 +439,7 @@ sub Run {
                         Message => $LayoutObject->{LanguageObject}->Translate(
                             'Could not delete ExpressionID %s!', $GetParam{DeleteExpressionID}
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 
@@ -465,7 +465,7 @@ sub Run {
                         Message => $LayoutObject->{LanguageObject}->Translate(
                             'Could not delete ActionID %s!', $GetParam{DeleteActionID}
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
 

--- a/Kernel/Modules/AgentITSMChangeDelete.pm
+++ b/Kernel/Modules/AgentITSMChangeDelete.pm
@@ -38,7 +38,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -75,7 +75,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -88,7 +88,7 @@ sub Run {
             Message => $LayoutObject->{LanguageObject}->Translate(
                 'Change "%s" does not have an allowed change state to be deleted!', $ChangeID
             ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMChangeEdit.pm
+++ b/Kernel/Modules/AgentITSMChangeEdit.pm
@@ -42,7 +42,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -82,7 +82,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -241,7 +241,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Could not perform validation on field %s!', $DynamicFieldConfig->{Label}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -480,7 +480,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message =>
                         $LayoutObject->{LanguageObject}->Translate( 'Was not able to update Change!', $ChangeID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }

--- a/Kernel/Modules/AgentITSMChangeInvolvedPersons.pm
+++ b/Kernel/Modules/AgentITSMChangeInvolvedPersons.pm
@@ -41,7 +41,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -78,7 +78,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -163,7 +163,7 @@ sub Run {
                         Message => $LayoutObject->{LanguageObject}->Translate(
                             'Was not able to update Change CAB for Change %s!', $ChangeID
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
             }
@@ -214,7 +214,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Was not able to update Change CAB for Change %s!', $ChangeID
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -251,7 +251,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message =>
                         $LayoutObject->{LanguageObject}->Translate( 'Was not able to update Change %s!', $ChangeID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }

--- a/Kernel/Modules/AgentITSMChangePrint.pm
+++ b/Kernel/Modules/AgentITSMChangePrint.pm
@@ -81,7 +81,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message =>
                     $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -93,7 +93,7 @@ sub Run {
             # error page
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Can\'t create output, as the workorder is not attached to a change!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -107,7 +107,7 @@ sub Run {
             # error page
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Can\'t create output, as no ChangeID is given!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -139,7 +139,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -304,7 +304,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -345,7 +345,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message =>
                     $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 

--- a/Kernel/Modules/AgentITSMChangeReset.pm
+++ b/Kernel/Modules/AgentITSMChangeReset.pm
@@ -39,7 +39,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -76,7 +76,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -145,7 +145,7 @@ sub Run {
                         $WorkOrderID,
                         $ChangeID
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }
@@ -194,7 +194,7 @@ sub Run {
             # show error message
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}->Translate( 'Was not able to reset Change %s!', $ChangeID ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }

--- a/Kernel/Modules/AgentITSMChangeTimeSlot.pm
+++ b/Kernel/Modules/AgentITSMChangeTimeSlot.pm
@@ -39,7 +39,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -77,7 +77,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -418,7 +418,7 @@ sub _MoveWorkOrders {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'Was not able to move time slot for workorder #%s!', $Number ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }

--- a/Kernel/Modules/AgentITSMChangeZoom.pm
+++ b/Kernel/Modules/AgentITSMChangeZoom.pm
@@ -40,7 +40,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -78,7 +78,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMTemplateDelete.pm
+++ b/Kernel/Modules/AgentITSMTemplateDelete.pm
@@ -57,7 +57,7 @@ sub Run {
     if ( !$TemplateID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TemplateID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -75,7 +75,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Template "%s" not found in database!', $TemplateID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -99,7 +99,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'Was not able to delete the template %s!', $TemplateID ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }

--- a/Kernel/Modules/AgentITSMTemplateEditCAB.pm
+++ b/Kernel/Modules/AgentITSMTemplateEditCAB.pm
@@ -66,7 +66,7 @@ sub Run {
     if ( !$GetParam{TemplateID} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TemplateID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -84,7 +84,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}
                 ->Translate( 'Template "%s" not found in database!', $GetParam{TemplateID} ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -177,7 +177,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'Was not able to update Template "%s"!', $GetParam{TemplateID} ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }

--- a/Kernel/Modules/AgentITSMTemplateEditContent.pm
+++ b/Kernel/Modules/AgentITSMTemplateEditContent.pm
@@ -60,7 +60,7 @@ sub Run {
     if ( !$TemplateID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No TemplateID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -78,7 +78,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Template "%s" not found in database!', $TemplateID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -123,7 +123,7 @@ sub Run {
 
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to create change from template!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -162,7 +162,7 @@ sub Run {
             if ( !$ChangeID ) {
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to create change!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -181,7 +181,7 @@ sub Run {
                 # show error message, when adding failed
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to create workorder from template!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 

--- a/Kernel/Modules/AgentITSMWorkOrderAdd.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderAdd.pm
@@ -40,7 +40,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -79,7 +79,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -247,7 +247,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Could not perform validation on field %s!', $DynamicFieldConfig->{Label}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -403,7 +403,7 @@ sub Run {
                 # show error message, when adding failed
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to add workorder!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }

--- a/Kernel/Modules/AgentITSMWorkOrderAddFromTemplate.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderAddFromTemplate.pm
@@ -39,7 +39,7 @@ sub Run {
     if ( !$ChangeID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No ChangeID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -78,7 +78,7 @@ sub Run {
     if ( !$Change ) {
         return $LayoutObject->ErrorScreen(
             Message => $LayoutObject->{LanguageObject}->Translate( 'Change "%s" not found in database!', $ChangeID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -182,7 +182,7 @@ sub Run {
                 # show error message, when adding failed
                 return $LayoutObject->ErrorScreen(
                     Message => Translatable('Was not able to create workorder from template!'),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 

--- a/Kernel/Modules/AgentITSMWorkOrderAgent.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderAgent.pm
@@ -39,7 +39,7 @@ sub Run {
     if ( !$WorkOrderID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No WorkOrderID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -57,7 +57,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -122,7 +122,7 @@ sub Run {
                         'Was not able to set the workorder agent of the workorder "%s" to empty!',
                         $WorkOrder->{WorkOrderID}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }
@@ -157,7 +157,7 @@ sub Run {
                         Message => $LayoutObject->{LanguageObject}->Translate(
                             'Was not able to update the workorder "%s"!', $WorkOrder->{WorkOrderID}
                         ),
-                        Comment => Translatable('Please contact the admin.'),
+                        Comment => Translatable('Please contact the administrator.'),
                     );
                 }
             }
@@ -196,7 +196,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Could not find Change for WorkOrder %s!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMWorkOrderEdit.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderEdit.pm
@@ -40,7 +40,7 @@ sub Run {
     if ( !$WorkOrderID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No WorkOrderID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -58,7 +58,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -273,7 +273,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Could not perform validation on field %s!', $DynamicFieldConfig->{Label}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -545,7 +545,7 @@ sub Run {
                                 Message => $LayoutObject->{LanguageObject}->Translate(
                                     'Was not able to update WorkOrder %s!', $WorkOrderID
                                 ),
-                                Comment => Translatable('Please contact the admin.'),
+                                Comment => Translatable('Please contact the administrator.'),
                             );
                         }
                     }
@@ -565,7 +565,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'Was not able to update WorkOrder %s!', $WorkOrderID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }
@@ -637,7 +637,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Could not find Change for WorkOrder %s!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMWorkOrderReport.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderReport.pm
@@ -40,7 +40,7 @@ sub Run {
     if ( !$WorkOrderID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No WorkOrderID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -79,7 +79,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -278,7 +278,7 @@ sub Run {
                     Message => $LayoutObject->{LanguageObject}->Translate(
                         'Could not perform validation on field %s!', $DynamicFieldConfig->{Label}
                     ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
 
@@ -461,7 +461,7 @@ sub Run {
                 return $LayoutObject->ErrorScreen(
                     Message => $LayoutObject->{LanguageObject}
                         ->Translate( 'Was not able to update WorkOrder %s!', $WorkOrderID ),
-                    Comment => Translatable('Please contact the admin.'),
+                    Comment => Translatable('Please contact the administrator.'),
                 );
             }
         }
@@ -536,7 +536,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Could not find Change for WorkOrder %s!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMWorkOrderTake.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderTake.pm
@@ -38,7 +38,7 @@ sub Run {
     if ( !$WorkOrderID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No WorkOrderID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -56,7 +56,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -104,7 +104,7 @@ sub Run {
             return $LayoutObject->ErrorScreen(
                 Message => $LayoutObject->{LanguageObject}
                     ->Translate( 'Was not able to take the workorder %s!', $WorkOrderID ),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -128,7 +128,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'Could not find Change for WorkOrder %s!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Modules/AgentITSMWorkOrderZoom.pm
+++ b/Kernel/Modules/AgentITSMWorkOrderZoom.pm
@@ -40,7 +40,7 @@ sub Run {
     if ( !$WorkOrderID ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No WorkOrderID is given!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -79,7 +79,7 @@ sub Run {
         return $LayoutObject->ErrorScreen(
             Message =>
                 $LayoutObject->{LanguageObject}->Translate( 'WorkOrder "%s" not found in database!', $WorkOrderID ),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeEdit.tt
@@ -9,7 +9,7 @@
 <div class="LayoutPopup ARIARoleMain">
 
     <div class="Header">
-        <h1>[% Translate("Edit") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
+        <h1>[% Translate("Edit %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>
         </p>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeHistory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeHistory.tt
@@ -10,7 +10,7 @@
 
     <div class="Header">
         <h1>
-            [% Translate("History of") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] - [% Data.ChangeTitle | truncate(60) | html %]
+            [% Translate("History of %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | truncate(60) | html %]
         </h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeHistoryZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeHistoryZoom.tt
@@ -10,7 +10,7 @@
 
     <div class="Header">
         <h1>
-            [% Translate("History of") | html %] [% Config("ITSMChange::Hook") %] [% Data.ChangeNumber | html %]: [% Data.ChangeTitle | truncate(60) | html %]
+            [% Translate("History of %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | truncate(60) | html %]
         </h1>
         <p>
             <a href="[% Env("Baselink") %]Action=AgentITSMChangeHistory;ChangeID=[% Data.ChangeID | uri %]">[% Translate("Back") | html %]</a>
@@ -20,7 +20,7 @@
     </div>
     <div class="Content">
 
-        <h2>[% Translate("Detailed history information of") | html %] [% Data.HistoryType %]</h2>
+        <h2>[% Translate("Detailed history information of %s", Data.HistoryType) | html %]</h2>
 
         <fieldset class="TableLike FixedLabel">
 

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeInvolvedPersons.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeInvolvedPersons.tt
@@ -69,8 +69,8 @@
 
     <div class="LayoutPopup ARIARoleMain">
         <div class="Header">
-            <h1 title="[% Translate("Edit") | html %] [% Translate("Involved Persons") | html %] [% Translate("of") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] &ndash; [% Data.ChangeTitle | html %]">
-                [% Translate("Edit") | html %] [% Translate("Involved Persons") | html %] [% Translate("of") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] &ndash; [% Data.ChangeTitle | truncate(70) | html %]
+            <h1 title="[% Translate("Edit Involved Persons of %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | html %]">
+                [% Translate("Edit Involved Persons of %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | truncate(70) | html %]
             </h1>
 
             <p>
@@ -123,9 +123,9 @@
                         <label for="TemplateID"> [% Translate("CAB Template") | html %]: </label>
                         <div class="Field">
                             [% Data.CABTemplateStrg %]
-                            <button type="submit" name="AddCABTemplateButton" id="AddCABTemplateButton" value="[% Translate("Apply Template") | html %]"> [% Translate("Apply Template") | html %] </button>
+                            <button class="CallForAction" type="submit" name="AddCABTemplateButton" id="AddCABTemplateButton" value="[% Translate("Apply Template") | html %]"><span>[% Translate("Apply Template") | html %]</span></button>
 [% RenderBlockStart("NewTemplateButton") %]
-                            <button type="submit" name="NewTemplateButton" id="NewTemplateButton" value="[% Translate("NewTemplate") | html %]"> [% Translate("Save this CAB as template") | html %] </button>
+                            <button class="CallForAction" type="submit" name="NewTemplateButton" id="NewTemplateButton" value="[% Translate("NewTemplate") | html %]"><span>[% Translate("Save this CAB as template") | html %]</span></button>
 [% RenderBlockEnd("NewTemplateButton") %]
                         </div>
 [% RenderBlockEnd("CABTemplate") %]
@@ -138,7 +138,7 @@
 
                             <div id="NewCABMemberServerError" class="TooltipErrorMessage"><p>[% Translate("User invalid.") | html %]</p></div>
 
-                            <button type="submit" id="AddCABMemberButton" name="AddCABMemberButton" value="[% Translate("Add") | html %]">[% Translate("Add") | html %]</button>
+                            <button class="CallForAction" type="submit" id="AddCABMemberButton" name="AddCABMemberButton" value="[% Translate("Add") | html %]"><span>[% Translate("Add") | html %]</span></button>
                         </div>
 
                         <div id="UserServerError" class="TooltipErrorMessage">

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeOverviewSmall.tt
@@ -37,27 +37,27 @@
 [% RenderBlockEnd("RecordWorkOrderNumberHeader") %]
 [% RenderBlockStart("RecordWorkOrderTitleHeader") %]
                 <th class="WorkOrderTitle [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderTitle") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Title") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordWorkOrderTitleHeader") %]
 [% RenderBlockStart("RecordChangeTitleHeader") %]
                 <th class="ChangeTitle [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeTitle") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Title") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordChangeTitleHeader") %]
 [% RenderBlockStart("RecordWorkOrderAgentHeader") %]
                 <th class="WorkOrderAgentID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderAgentID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderAgent") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderAgentID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Agent") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordWorkOrderAgentHeader") %]
 [% RenderBlockStart("RecordChangeBuilderHeader") %]
                 <th class="ChangeBuilderID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeBuilderID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeBuilder") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeBuilderID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Builder") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordChangeBuilderHeader") %]
 [% RenderBlockStart("RecordChangeManagerHeader") %]
                 <th class="ChangeBuilderID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeManagerID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeManager") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeManagerID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Manager") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordChangeManagerHeader") %]
 [% RenderBlockStart("RecordWorkOrderCountHeader") %]
@@ -65,17 +65,17 @@
 [% RenderBlockEnd("RecordWorkOrderCountHeader") %]
 [% RenderBlockStart("RecordChangeStateHeader") %]
                 <th class="ChangeStateID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeState") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change State") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordChangeStateHeader") %]
 [% RenderBlockStart("RecordWorkOrderStateHeader") %]
                 <th class="WorkOrderStateID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderState") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder State") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordWorkOrderStateHeader") %]
 [% RenderBlockStart("RecordWorkOrderTypeHeader") %]
                 <th class="WorkOrderTypeID [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTypeID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderType") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTypeID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Type") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordWorkOrderTypeHeader") %]
 [% RenderBlockStart("RecordCategoryHeader") %]
@@ -109,22 +109,22 @@
 [% RenderBlockEnd("RecordRequestedTimeHeader") %]
 [% RenderBlockStart("RecordPlannedStartTimeHeader") %]
                 <th class="PlannedStartTime [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("PlannedStartTime") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Planned Start Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordPlannedStartTimeHeader") %]
 [% RenderBlockStart("RecordPlannedEndTimeHeader") %]
                 <th class="PlannedEndTime [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("PlannedEndTime") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Planned End Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordPlannedEndTimeHeader") %]
 [% RenderBlockStart("RecordActualStartTimeHeader") %]
                 <th class="ActualStartTime [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ActualStartTime") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Actual Start Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordActualStartTimeHeader") %]
 [% RenderBlockStart("RecordActualEndTimeHeader") %]
                 <th class="ActualEndTime [% Data.CSS | html %]">
-                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ActualEndTime") | html %]</a>
+                    <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Actual End Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordActualEndTimeHeader") %]
 [% RenderBlockStart("RecordCreateTimeHeader") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeSearch.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeSearch.tt
@@ -20,13 +20,13 @@
                 [% Data.ProfilesStrg %]
                 <div id="SearchProfileAddBlock">
                     <input type="text" name="Name" id="SearchProfileAddName"/>
-                    <button type="button" title="[% Translate("Create Template") | html %]" id="SearchProfileAddAction">[% Translate("Add") | html %]</button>
+                    <button class="CallForAction" type="button" title="[% Translate("Create Template") | html %]" id="SearchProfileAddAction"><span>[% Translate("Add") | html %]</span></button>
                 </div>
             </div>
             <div class="Field">
-                <button id="SearchProfileNew" value="[% Translate("Create New") | html %]">[% Translate("Create New") | html %]</button>
-                <button id="SearchProfileDelete" class="Hidden" value="[% Translate("Delete") | html %]">[% Translate("Delete") | html %]</button>
-                <button id="SearchProfileAsLink" class="Hidden" value="[% Translate("Profile link") | html %]">[% Translate("Profile link") | html %]</button>
+                <button id="SearchProfileNew" class="CallForAction" value="[% Translate("Create New") | html %]"><span>[% Translate("Create New") | html %]</span></button>
+                <button id="SearchProfileDelete" class="CallForAction Hidden" value="[% Translate("Delete") | html %]"><span>[% Translate("Delete") | html %]</span></button>
+                <button id="SearchProfileAsLink" class="CallForAction Hidden" value="[% Translate("Profile link") | html %]"><span>[% Translate("Profile link") | html %]</span></button>
             </div>
             <div class="Clear"></div>
             <label>[% Translate("Save changes in template") | html %]:</label>
@@ -67,26 +67,26 @@
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="ChangeTitle" id="LabelChangeTitle">[% Translate("ChangeTitle") | html %]:</label>
+        <label for="ChangeTitle" id="LabelChangeTitle">[% Translate("Change Title") | html %]:</label>
         <div class="Field">
             <input type="text" name="ChangeTitle" value="[% Data.ChangeTitle | html %]" class="W50pc"/>
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderTitle" id="LabelWorkOrderTitle">[% Translate("WorkOrderTitle") | html %]:</label>
+        <label for="WorkOrderTitle" id="LabelWorkOrderTitle">[% Translate("Workorder Title") | html %]:</label>
         <div class="Field">
             <input type="text" name="WorkOrderTitle" value="[% Data.WorkOrderTitle | html %]" class="W50pc"/>
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="CABAgent" id="LabelCABAgent">[% Translate("CABAgent") | html %] ([% Translate("e.g.") | html %] 234231):</label>
+        <label for="CABAgent" id="LabelCABAgent">[% Translate("CAB Agent") | html %] ([% Translate("e.g.") | html %] 234231):</label>
         <div class="Field">
             <input type="hidden" id="CABAgentSelected" value="[% Data.CABAgent | html %]" name="CABAgent">
             <input type="text" name="CABAgentSearch" value="[% Data.CABAgentSearch | html %]" class="W50pc ITSMUserSearch"/>
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="CABCustomer" id="LabelCABCustomer">[% Translate("CABCustomer") | html %] ([% Translate("e.g.") | html %] US4231):</label>
+        <label for="CABCustomer" id="LabelCABCustomer">[% Translate("CAB Customer") | html %] ([% Translate("e.g.") | html %] US4231):</label>
         <div class="Field">
             <input type="hidden" id="CABCustomerSelected" value="[% Data.CABCustomer | html %]" name="CABCustomer">
             <input type="text" name="CABCustomerSearch" value="[% Data.CABCustomerSearch | html %]" class="W50pc ITSMCustomerSearch"/>
@@ -105,13 +105,13 @@
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderInstruction" id="LabelWorkOrderInstruction">[% Translate("ITSM Workorder") | html %] [% Translate("Instruction") | html %] ([% Translate("e.g.") | html %] "Mar*in" [% Translate("or") | html %] "Baue*"):</label>
+        <label for="WorkOrderInstruction" id="LabelWorkOrderInstruction">[% Translate("ITSM Workorder Instruction") | html %] ([% Translate("e.g.") | html %] "Mar*in" [% Translate("or") | html %] "Baue*"):</label>
         <div class="Field">
             <input type="text" name="WorkOrderInstruction" value="[% Data.WorkOrderInstruction | html %]" class="W50pc"/>
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderReport" id="LabelWorkOrderReport">[% Translate("ITSM Workorder") | html %] [% Translate("Report") | html %] ([% Translate("e.g.") | html %] "Mar*in" [% Translate("or") | html %] "Baue*"):</label>
+        <label for="WorkOrderReport" id="LabelWorkOrderReport">[% Translate("ITSM Workorder Report") | html %] ([% Translate("e.g.") | html %] "Mar*in" [% Translate("or") | html %] "Baue*"):</label>
         <div class="Field">
             <input type="text" name="WorkOrderReport" value="[% Data.WorkOrderReport | html %]" class="W50pc"/>
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
@@ -128,13 +128,13 @@
 [% RenderBlockEnd("DynamicField") %]
 
         <div class="Clear"></div>
-        <label for="PriorityIDs" id="LabelPriorityIDs">[% Translate("ITSM Change") | html %] [% Translate("Priority") | html %]:</label>
+        <label for="PriorityIDs" id="LabelPriorityIDs">[% Translate("ITSM Change Priority") | html %]:</label>
         <div class="Field">
             [% Data.ChangePrioritySelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="ImpactIDs" id="LabelImpactIDs">[% Translate("ITSM Change") | html %] [% Translate("Impact") | html %]:</label>
+        <label for="ImpactIDs" id="LabelImpactIDs">[% Translate("ITSM Change Impact") | html %]:</label>
         <div class="Field">
             [% Data.ChangeImpactSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
@@ -146,19 +146,19 @@
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="ChangeStateIDs" id="LabelChangeStateIDs">[% Translate("ChangeState") | html %]:</label>
+        <label for="ChangeStateIDs" id="LabelChangeStateIDs">[% Translate("Change State") | html %]:</label>
         <div class="Field">
             [% Data.ChangeStateSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="ChangeManagerIDs" id="LabelChangeManagerIDs">[% Translate("ChangeManager") | html %]:</label>
+        <label for="ChangeManagerIDs" id="LabelChangeManagerIDs">[% Translate("Change Manager") | html %]:</label>
         <div class="Field">
             [% Data.ChangeManagerSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="ChangeBuilderIDs" id="LabelChangeBuilderIDs">[% Translate("ChangeBuilder") | html %]:</label>
+        <label for="ChangeBuilderIDs" id="LabelChangeBuilderIDs">[% Translate("Change Builder") | html %]:</label>
         <div class="Field">
             [% Data.ChangeBuilderSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
@@ -170,19 +170,19 @@
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderStateIDs" id="LabelWorkOrderStateIDs">[% Translate("WorkOrderState") | html %]:</label>
+        <label for="WorkOrderStateIDs" id="LabelWorkOrderStateIDs">[% Translate("Workorder State") | html %]:</label>
         <div class="Field">
             [% Data.WorkOrderStateSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderTypeIDs" id="LabelWorkOrderTypeIDs">[% Translate("WorkOrderType") | html %]:</label>
+        <label for="WorkOrderTypeIDs" id="LabelWorkOrderTypeIDs">[% Translate("Workorder Type") | html %]:</label>
         <div class="Field">
             [% Data.WorkOrderTypeSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>
         </div>
         <div class="Clear"></div>
-        <label for="WorkOrderAgentIDs" id="LabelWorkOrderAgentIDs">[% Translate("WorkOrderAgent") | html %]:</label>
+        <label for="WorkOrderAgentIDs" id="LabelWorkOrderAgentIDs">[% Translate("Workorder Agent") | html %]:</label>
         <div class="Field">
             [% Data.WorkOrderAgentIDSelectionString %]
             <a class="RemoveButton" href="#" title="[% Translate("Remove this entry") | html %]"><i class="fa fa-minus-square-o"></i><span class="InvisibleText">[% Translate("Remove") | html %]</span></a>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMChangeZoom.tt
@@ -30,7 +30,7 @@
                 <div class="Content">
 [% RenderBlockStart("Meta") %]
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label>[% Translate("ChangeState") | html %]:</label>
+                        <label>[% Translate("Change State") | html %]:</label>
                         <div class="Value">
                             <div class="Flag Small">
                                 <span class="[% Data.ChangeStateSignal | html %]">[% Translate(Data.ChangeState) | html %]</span>
@@ -41,7 +41,7 @@
                     </fieldset>
 
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label>[% Translate("PlannedStartTime") | html %]:</label>
+                        <label>[% Translate("Planned Start Time") | html %]:</label>
 [% RenderBlockStart("EmptyPlannedStartTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedStartTime") %]
@@ -50,7 +50,7 @@
 [% RenderBlockEnd("PlannedStartTime") %]
                         <div class="Clear"></div>
 
-                        <label>[% Translate("PlannedEndTime") | html %]: </label>
+                        <label>[% Translate("Planned End Time") | html %]: </label>
 [% RenderBlockStart("EmptyPlannedEndTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedEndTime") %]
@@ -59,7 +59,7 @@
 [% RenderBlockEnd("PlannedEndTime") %]
                         <div class="Clear"></div>
 
-                        <label>[% Translate("ActualStartTime") | html %]: </label>
+                        <label>[% Translate("Actual Start Time") | html %]: </label>
 [% RenderBlockStart("EmptyActualStartTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyActualStartTime") %]
@@ -68,7 +68,7 @@
 [% RenderBlockEnd("ActualStartTime") %]
                         <div class="Clear"></div>
 
-                        <label>[% Translate("ActualEndTime") | html %]: </label>
+                        <label>[% Translate("Actual End Time") | html %]: </label>
 [% RenderBlockStart("EmptyActualEndTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyActualEndTime") %]
@@ -93,7 +93,7 @@
 
                     <fieldset class="TableLike FixedLabelSmall">
 [% RenderBlockStart("ShowPlannedEffort") %]
-                        <label>[% Translate("PlannedEffort") | html %]: </label>
+                        <label>[% Translate("Planned Effort") | html %]: </label>
 [% RenderBlockStart("EmptyPlannedEffort") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedEffort") %]
@@ -104,7 +104,7 @@
 [% RenderBlockEnd("ShowPlannedEffort") %]
 
 [% RenderBlockStart("ShowAccountedTime") %]
-                        <label>[% Translate("AccountedTime") | html %]: </label>
+                        <label>[% Translate("Accounted Time") | html %]: </label>
 [% RenderBlockStart("EmptyAccountedTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyAccountedTime") %]
@@ -314,7 +314,7 @@
             <div class="WidgetBox SpacingTop Expanded">
                 <div class="LightRow Header">
                     <div class="WidgetAction Toggle"><a href="#" title="[% Translate("Show or hide the content.") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a></div>
-                    <h2>[% Translate("ITSMChange") | html %] - [% Data.ChangeTitle | truncate(70) | html %]</h2>
+                    <h2>[% Translate("ITSM Change") | html %] - [% Data.ChangeTitle | truncate(70) | html %]</h2>
                 </div>
                 <div class="Content">
                     <fieldset class="TableLike FixedLabelSmall">

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMTemplateEditCAB.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMTemplateEditCAB.tt
@@ -50,7 +50,7 @@
 
                             <div id="NewCABMemberServerError" class="TooltipErrorMessage"><p>[% Translate("User invalid.") | html %]</p></div>
 
-                            <button type="submit" id="AddCABMember" name="AddCABMember" value="[% Translate("Add") | html %]">[% Translate("Add") | html %]</button>
+                            <button class="CallForAction" type="submit" id="AddCABMember" name="AddCABMember" value="[% Translate("Add") | html %]"><span>[% Translate("Add") | html %]</span></button>
                         </div>
 
                         <div id="UserServerError" class="TooltipErrorMessage">
@@ -113,7 +113,7 @@ $('#[% Data.InternalUserType %][% Data.UserID | html %]').bind('click', function
 [% RenderBlockEnd("CABMemberTable") %]
                 </div>
                 <div class="Field SpacingTop SpacingBottom SpacingLeft">
-                    <button class="Primary" type="submit" Name="Submit" value="[% Translate("Save") | html %]">[% Translate("Save") | html %]</button>
+                    <button class="Primary CallForAction" type="submit" Name="Submit" value="[% Translate("Save") | html %]"><span>[% Translate("Save") | html %]</span></button>
                 </div>
             </div>
         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMTemplateOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMTemplateOverviewSmall.tt
@@ -11,7 +11,7 @@
         <thead>
             <tr>
 [% RenderBlockStart("RecordTemplateIDHeader") %]
-                <th><span>[% Translate("TemplateID") | html %]</span></th>
+                <th><span>[% Translate("Template ID") | html %]</span></th>
 [% RenderBlockEnd("RecordTemplateIDHeader") %]
 [% RenderBlockStart("RecordNameHeader") %]
                 <th class="Name [% Data.SortName | html %]">
@@ -38,19 +38,19 @@
                 <th class="Center Last"><span>[% Translate("Delete") | html %]</span></th>
 [% RenderBlockEnd("RecordDeleteHeader") %]
 [% RenderBlockStart("RecordCreateByHeader") %]
-                <th><span>[% Translate("CreateBy") | html %]</span></th>
+                <th><span>[% Translate("Create by") | html %]</span></th>
 [% RenderBlockEnd("RecordCreateByHeader") %]
 [% RenderBlockStart("RecordCreateTimeHeader") %]
                 <th class="CreateTime [% Data.SortCreateTime | html %]">
-                    <a name="OverviewControl" href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=CreateTime;OrderBy=[% Data.OrderByCreateTime | uri %]">[% Translate("CreateTime") | html %]</a>
+                    <a name="OverviewControl" href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=CreateTime;OrderBy=[% Data.OrderByCreateTime | uri %]">[% Translate("Create Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordCreateTimeHeader") %]
 [% RenderBlockStart("RecordChangeByHeader") %]
-                <th><span>[% Translate("ChangeBy") | html %]</span></th>
+                <th><span>[% Translate("Change by") | html %]</span></th>
 [% RenderBlockEnd("RecordChangeByHeader") %]
 [% RenderBlockStart("RecordChangeTimeHeader") %]
                 <th class="ChangeTime [% Data.SortChangeTime | html %]">
-                    <a name="OverviewControl" href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTime;OrderBy=[% Data.OrderByChangeTime | uri %]">[% Translate("ChangeTime") | html %]</a>
+                    <a name="OverviewControl" href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTime;OrderBy=[% Data.OrderByChangeTime | uri %]">[% Translate("Change Time") | html %]</a>
                 </th>
 [% RenderBlockEnd("RecordChangeTimeHeader") %]
             </tr>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAdd.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAdd.tt
@@ -9,7 +9,7 @@
 <div class="LayoutPopup ARIARoleMain">
 
     <div class="Header">
-        <h1>[% Translate("Add Workorder to") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
+        <h1>[% Translate("Add Workorder to %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>
         </p>
@@ -50,7 +50,7 @@
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="WorkOrderTypeID">[% Translate("WorkOrderType") | html %]:</label>
+                        <label for="WorkOrderTypeID">[% Translate("Workorder Type") | html %]:</label>
                         <div class="Field">
                             [% Data.WorkOrderTypeStrg %]
                         </div>
@@ -89,7 +89,7 @@
 #                        </div>
 #[% RenderBlockEnd("DynamicField_Field2") %]
 
-                        <label>[% Translate("PlannedStartTime") | html %]:</label>
+                        <label>[% Translate("Planned Start Time") | html %]:</label>
                         <div class="Field">
                             [% Data.PlannedStartTimeSelectionString %]
                             <div id="PlannedStartTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Invalid date!") | html %]</p></div>
@@ -105,7 +105,7 @@
                         </div>
                         <div class="Clear"></div>
 
-                        <label>[% Translate("PlannedEndTime") | html %]:</label>
+                        <label>[% Translate("Planned End Time") | html %]:</label>
                         <div class="Field">
                             [% Data.PlannedEndTimeSelectionString %]
                             <div id="PlannedEndTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Invalid date!") | html %]</p></div>
@@ -122,7 +122,7 @@
                         <div class="Clear"></div>
 
 [% RenderBlockStart("ShowPlannedEffort") %]
-                        <label for="PlannedEffort">[% Translate("PlannedEffort") | html %]:</label>
+                        <label for="PlannedEffort">[% Translate("Planned Effort") | html %]:</label>
                         <div class="Field">
                             <input type="text" name="PlannedEffort" id="PlannedEffort" value="[% Data.PlannedEffort | html %]" class="W10pc Validate [% Data.PlannedEffortInvalid | html %]" maxlength="10"/>
                             <div id="PlannedEffortError" class="TooltipErrorMessage"><p>[% Translate("Invalid format.") | html %]</p></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAddFromTemplate.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAddFromTemplate.tt
@@ -9,7 +9,7 @@
 <div class="LayoutPopup ARIARoleMain">
 
     <div class="Header">
-        <h1>[% Translate("Add Workorder to") | html %] [% Config("ITSMChange::Hook") %]: [% Data.ChangeNumber | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
+        <h1>[% Translate("Add Workorder to %s%s", Config("ITSMChange::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.ChangeTitle | html %]</h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>
         </p>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAgent.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderAgent.tt
@@ -29,8 +29,8 @@
 
     <div class="LayoutPopup ARIARoleMain">
         <div class="Header">
-            <h1 title="[% Translate("Edit") | html %] [% Translate("WorkOrderAgent") | html %] [% Translate("of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %] &ndash; [% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | html %]">
-                [% Translate("Edit") | html %] [% Translate("WorkOrderAgent") | html %] [% Translate("of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %] &ndash; [% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(70) | html %]
+            <h1 title="[% Translate("Edit Workorder Agent of %s%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | html %]">
+                [% Translate("Edit Workorder Agent of %s%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber) | html %] &ndash; [% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(70) | html %]
             </h1>
             <p>
                 <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>
@@ -40,7 +40,7 @@
         <div class="Content SpacingBottom">
             <fieldset class="TableLike FixedLabel">
 
-                <label for="User"> [% Translate("WorkOrderAgent") | html %]: </label>
+                <label for="User"> [% Translate("Workorder Agent") | html %]: </label>
                 <div class="Field">
                     <input id="User" type="text" name="User" value="[% Data.User | html %]" class="W75pc [% Data.UserServerError %]"/>
                     <input id="UserSelected" type="hidden" name="UserSelected" value="[% Data.UserID | html %]" />

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderEdit.tt
@@ -9,7 +9,7 @@
 <div class="LayoutPopup ARIARoleMain">
 
     <div class="Header">
-        <h1>[% Translate("Edit") | html %] [% Config("ITSMWorkOrder::Hook") %]: [% Data.ChangeNumber | html %]-[% Data.WorkOrderNumber | html %] &mdash; [% Data.WorkOrderTitle | html %]</h1>
+        <h1>[% Translate("Edit %s%s-%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber, Data.WorkOrderNumber) | html %] &mdash; [% Data.WorkOrderTitle | html %]</h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>
         </p>
@@ -45,7 +45,7 @@
                     </div>
                     <div class="Clear"></div>
 
-                    <label>[% Translate("WorkOrderType") | html %]:</label>
+                    <label>[% Translate("Workorder Type") | html %]:</label>
                     <div class="Field">
                         [% Translate(Data.WorkOrderType) | html %]
                     </div>
@@ -83,7 +83,7 @@
 #                    </div>
 #[% RenderBlockEnd("DynamicField_Field2") %]
 
-                    <label>[% Translate("PlannedStartTime") | html %]:</label>
+                    <label>[% Translate("Planned Start Time") | html %]:</label>
                     <div class="Field">
                         [% Data.PlannedStartTimeSelectionString %]
                         <div id="PlannedStartTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Invalid date!") | html %]</p></div>
@@ -99,7 +99,7 @@
                     </div>
                     <div class="Clear"></div>
 
-                    <label>[% Translate("PlannedEndTime") | html %]:</label>
+                    <label>[% Translate("Planned End Time") | html %]:</label>
                     <div class="Field">
                         [% Data.PlannedEndTimeSelectionString %]
                         <div id="PlannedEndTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Invalid date!") | html %]</p></div>
@@ -124,7 +124,7 @@
 [% RenderBlockEnd("MoveFollowingWorkOrders") %]
 
 [% RenderBlockStart("ShowPlannedEffort") %]
-                    <label for="PlannedEffort">[% Translate("PlannedEffort") | html %]:</label>
+                    <label for="PlannedEffort">[% Translate("Planned Effort") | html %]:</label>
                     <div class="Field">
                         <input type="text" name="PlannedEffort" id="PlannedEffort" value="[% Data.PlannedEffort | html %]" class="W10pc Validate [% Data.PlannedEffortInvalid | html %]" maxlength="10"/>
                         <div id="PlannedEffortError" class="TooltipErrorMessage"><p>[% Translate("Invalid format.") | html %]</p></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistory.tt
@@ -10,7 +10,7 @@
 
     <div class="Header">
         <h1>
-            [% Translate("History of") | html %] [% Config("ITSMWorkOrder::Hook") %]: [% Data.ChangeNumber | html %]-[% Data.WorkOrderNumber | html %] - [% Data.WorkOrderTitle | truncate(60) | html %]
+            [% Translate("History of %s%s-%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber, Data.WorkOrderNumber) | html %] &ndash; [% Data.WorkOrderTitle | truncate(60) | html %]
         </h1>
         <p>
             <a href="#" class="CancelClosePopup">[% Translate("Cancel & close") | html %]</a>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderHistoryZoom.tt
@@ -10,7 +10,7 @@
 
     <div class="Header">
         <h1>
-            [% Translate("History of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %]-[% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(60) | html %]
+            [% Translate("History of %s%s-%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber, Data.WorkOrderNumber) | html %] &ndash; [% Data.WorkOrderTitle | truncate(60) | html %]
         </h1>
         <p>
             <a href="[% Env("Baselink") %]Action=AgentITSMWorkOrderHistory;WorkOrderID=[% Data.WorkOrderID | uri %]">[% Translate("Back") | html %]</a>
@@ -20,7 +20,7 @@
     </div>
     <div class="Content">
 
-        <h2>[% Translate("Detailed history information of") | html %] [% Data.HistoryType %]</h2>
+        <h2>[% Translate("Detailed history information of %s", Data.HistoryType) | html %]</h2>
         <fieldset class="TableLike FixedLabel">
 
             <label>[% Translate("Modified") | html %]:</label>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderReport.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderReport.tt
@@ -15,7 +15,7 @@
 
     <div class="LayoutPopup ARIARoleMain">
         <div class="Header">
-            <h1>[% Translate("Edit") | html %]: [% Translate("Report") | html %] [% Translate("of") | html %] [% Config("ITSMWorkOrder::Hook") %] [% Data.ChangeNumber | html %] - [% Data.WorkOrderNumber | html %]: [% Data.WorkOrderTitle | truncate(60) | html %]</h1>
+            <h1>[% Translate("Edit Report of %s%s-%s", Config("ITSMWorkOrder::Hook"), Data.ChangeNumber, Data.WorkOrderNumber) | html %] &ndash; [% Data.WorkOrderTitle | truncate(60) | html %]</h1>
             <p>
                 <a class="CancelClosePopup" href="#">[% Translate("Cancel & close") | html %]</a>
             </p>
@@ -76,7 +76,7 @@
 #[% RenderBlockEnd("DynamicField_Field2") %]
 
 [% RenderBlockStart("ActualStartTime") %]
-                <label>[% Translate("ActualStartTime") | html %]:</label>
+                <label>[% Translate("Actual Start Time") | html %]:</label>
                 <div class="Field">
                     [% Data.ActualStartTimeSelectionString %]
                     <div id="ActualStartTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Invalid date!") | html %]</p></div>
@@ -98,7 +98,7 @@
 [% RenderBlockEnd("ActualStartTime") %]
 
 [% RenderBlockStart("ActualEndTime") %]
-                <label>[% Translate("ActualEndTime") | html %]:</label>
+                <label>[% Translate("Actual End Time") | html %]:</label>
                 <div class="Field">
                     [% Data.ActualEndTimeSelectionString %]
                     <div id="ActualEndTimeDayError" class="TooltipErrorMessage"><p>[% Translate("Date invalid!") | html %]</p></div>
@@ -110,7 +110,7 @@
 [% RenderBlockEnd("ActualEndTime") %]
 
 [% RenderBlockStart("ShowAccountedTime") %]
-                <label for="AccountedTime">[% Translate("AccountedTime") | html %]:</label>
+                <label for="AccountedTime">[% Translate("Accounted Time") | html %]:</label>
                 <div class="Field">
                     <input type="text" id="AccountedTime" name="AccountedTime" value="[% Data.AccountedTime | html %]" class="25pc Validate [% Data.AccountedTimeInvalid | html %]" maxlength="11"/>
                     <div id="AccountedTimeError" class="TooltipErrorMessage" ><p>[% Translate("Invalid format.") | html %]</p></div>

--- a/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderZoom.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentITSMWorkOrderZoom.tt
@@ -29,7 +29,7 @@
                 <div class="Content">
 [% RenderBlockStart("Meta") %]
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label>[% Translate("WorkOrderState") | html %]:</label>
+                        <label>[% Translate("Workorder State") | html %]:</label>
                         <div class="Value">
                             <div class="Flag Small">
                                 <span class="[% Data.WorkOrderStateSignal | html %]">[% Translate(Data.WorkOrderState) | html %]</span>
@@ -38,7 +38,7 @@
                         </div>
                         <div class="Clear"></div>
 
-                        <label>[% Translate("WorkOrderType") | html %]:</label>
+                        <label>[% Translate("Workorder Type") | html %]:</label>
 [% RenderBlockStart("EmptyWorkOrderType") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyWorkOrderType") %]
@@ -49,7 +49,7 @@
                     </fieldset>
 
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label>[% Translate("PlannedStartTime") | html %]:</label>
+                        <label>[% Translate("Planned Start Time") | html %]:</label>
 [% RenderBlockStart("EmptyPlannedStartTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedStartTime") %]
@@ -59,7 +59,7 @@
                         <div class="Clear"></div>
 
 
-                        <label>[% Translate("PlannedEndTime") | html %]: </label>
+                        <label>[% Translate("Planned End Time") | html %]: </label>
 [% RenderBlockStart("EmptyPlannedEndTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedEndTime") %]
@@ -68,7 +68,7 @@
 [% RenderBlockEnd("PlannedEndTime") %]
                         <div class="Clear"></div>
 
-                        <label>[% Translate("ActualStartTime") | html %]: </label>
+                        <label>[% Translate("Actual Start Time") | html %]: </label>
 [% RenderBlockStart("EmptyActualStartTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyActualStartTime") %]
@@ -77,7 +77,7 @@
 [% RenderBlockEnd("ActualStartTime") %]
                         <div class="Clear"></div>
 
-                        <label>[% Translate("ActualEndTime") | html %]: </label>
+                        <label>[% Translate("Actual End Time") | html %]: </label>
 [% RenderBlockStart("EmptyActualEndTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyActualEndTime") %]
@@ -89,7 +89,7 @@
 
                     <fieldset class="TableLike FixedLabelSmall">
 [% RenderBlockStart("ShowPlannedEffort") %]
-                        <label>[% Translate("PlannedEffort") | html %]: </label>
+                        <label>[% Translate("Planned Effort") | html %]: </label>
 [% RenderBlockStart("EmptyPlannedEffort") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyPlannedEffort") %]
@@ -100,7 +100,7 @@
 [% RenderBlockEnd("ShowPlannedEffort") %]
 
 [% RenderBlockStart("ShowAccountedTime") %]
-                        <label>[% Translate("AccountedTime") | html %]: </label>
+                        <label>[% Translate("Accounted Time") | html %]: </label>
 [% RenderBlockStart("EmptyAccountedTime") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyAccountedTime") %]
@@ -171,7 +171,7 @@
                     </fieldset>
 
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label>[% Translate("WorkOrderAgent") | html %]:</label>
+                        <label>[% Translate("Workorder Agent") | html %]:</label>
 [% RenderBlockStart("EmptyWorkOrderAgent") %]
                         <p class="Value" title="-">-</p>
 [% RenderBlockEnd("EmptyWorkOrderAgent") %]
@@ -257,7 +257,7 @@
                 </div>
                 <div class="Content">
                     <fieldset class="TableLike FixedLabelSmall">
-                        <label><strong>[% Translate("ITSMChange") | html %]</strong></label>
+                        <label><strong>[% Translate("ITSM Change") | html %]</strong></label>
                         <div class="Value">
                             <div class="Flag Small">
                                 <span class="[% Data.ChangeStateSignal | html %]">[% Translate(Data.ChangeState) | html %]</span>

--- a/Kernel/Output/HTML/Templates/Standard/CustomerITSMChangeOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/CustomerITSMChangeOverview.tt
@@ -48,27 +48,27 @@
 [% RenderBlockEnd("RecordWorkOrderNumberHeader") %]
 [% RenderBlockStart("RecordWorkOrderTitleHeader") %]
                     <th class="WorkOrderTitle [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderTitle") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Title") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordWorkOrderTitleHeader") %]
 [% RenderBlockStart("RecordChangeTitleHeader") %]
                     <th class="ChangeTitle [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeTitle") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeTitle;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Title") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordChangeTitleHeader") %]
 [% RenderBlockStart("RecordWorkOrderAgentHeader") %]
                     <th class="WorkOrderAgentID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderAgentID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderAgent") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderAgentID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Agent") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordWorkOrderAgentHeader") %]
 [% RenderBlockStart("RecordChangeBuilderHeader") %]
                     <th class="ChangeBuilderID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeBuilderID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeBuilder") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeBuilderID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Builder") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordChangeBuilderHeader") %]
 [% RenderBlockStart("RecordChangeManagerHeader") %]
                     <th class="ChangeBuilderID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeManagerID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeManager") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeManagerID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change Manager") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordChangeManagerHeader") %]
 [% RenderBlockStart("RecordWorkOrderCountHeader") %]
@@ -76,17 +76,17 @@
 [% RenderBlockEnd("RecordWorkOrderCountHeader") %]
 [% RenderBlockStart("RecordChangeStateHeader") %]
                     <th class="ChangeStateID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ChangeState") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ChangeStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Change State") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordChangeStateHeader") %]
 [% RenderBlockStart("RecordWorkOrderStateHeader") %]
                     <th class="WorkOrderStateID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderState") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderStateID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder State") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordWorkOrderStateHeader") %]
 [% RenderBlockStart("RecordWorkOrderTypeHeader") %]
                     <th class="WorkOrderTypeID [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTypeID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("WorkOrderType") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=WorkOrderTypeID;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Workorder Type") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordWorkOrderTypeHeader") %]
 [% RenderBlockStart("RecordCategoryHeader") %]
@@ -116,22 +116,22 @@
 [% RenderBlockEnd("RecordRequestedTimeHeader") %]
 [% RenderBlockStart("RecordPlannedStartTimeHeader") %]
                     <th class="PlannedStartTime [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("PlannedStartTime") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Planned Start Time") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordPlannedStartTimeHeader") %]
 [% RenderBlockStart("RecordPlannedEndTimeHeader") %]
                     <th class="PlannedEndTime [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("PlannedEndTime") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=PlannedEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Planned End Time") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordPlannedEndTimeHeader") %]
 [% RenderBlockStart("RecordActualStartTimeHeader") %]
                     <th class="ActualStartTime [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ActualStartTime") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualStartTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Actual Start Time") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordActualStartTimeHeader") %]
 [% RenderBlockStart("RecordActualEndTimeHeader") %]
                     <th class="ActualEndTime [% Data.CSS | html %]">
-                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("ActualEndTime") | html %]</a>
+                        <a href="[% Env("Baselink") %]Action=[% Env("Action") %];[% Data.LinkSort %];SortBy=ActualEndTime;OrderBy=[% Data.OrderBy | uri %]">[% Translate("Actual End Time") | html %]</a>
                     </th>
 [% RenderBlockEnd("RecordActualEndTimeHeader") %]
 [% RenderBlockStart("RecordCreateTimeHeader") %]

--- a/Kernel/Output/HTML/Templates/Standard/ITSMChange.tt
+++ b/Kernel/Output/HTML/Templates/Standard/ITSMChange.tt
@@ -110,7 +110,7 @@
 [% RenderBlockEnd("DynamicField") %]
 
 [% RenderBlockStart("WorkOrderAgentBlock") %]
-                    <label>[% Translate("WorkOrderAgent") | html %]:</label>
+                    <label>[% Translate("Workorder Agent") | html %]:</label>
 [% RenderBlockStart("EmptyWorkOrderAgent") %]
                     <p class="Value">-</p>
 [% RenderBlockEnd("EmptyWorkOrderAgent") %]
@@ -135,37 +135,37 @@
 [% RenderBlockEnd("Report") %]
 
 [% RenderBlockStart("PlannedEffort") %]
-                    <label>[% Translate("PlannedEffort") | html %]:</label>
+                    <label>[% Translate("Planned Effort") | html %]:</label>
                     <p class="Value">[% Data.PlannedEffort | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("PlannedEffort") %]
 
 [% RenderBlockStart("AccountedTime") %]
-                    <label>[% Translate("AccountedTime") | html %]:</label>
+                    <label>[% Translate("Accounted Time") | html %]:</label>
                     <p class="Value">[% Data.AccountedTime | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("AccountedTime") %]
 
 [% RenderBlockStart("PlannedStartTime") %]
-                    <label>[% Translate("PlannedStartTime") | html %]:</label>
+                    <label>[% Translate("Planned Start Time") | html %]:</label>
                     <p class="Value">[% Data.PlannedStartTime | Localize("TimeLong") %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("PlannedStartTime") %]
 
 [% RenderBlockStart("PlannedEndTime") %]
-                    <label>[% Translate("PlannedEndTime") | html %]:</label>
+                    <label>[% Translate("Planned End Time") | html %]:</label>
                     <p class="Value">[% Data.PlannedEndTime | Localize("TimeLong") %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("PlannedEndTime") %]
 
 [% RenderBlockStart("ActualStartTime") %]
-                    <label>[% Translate("ActualStartTime") | html %]:</label>
+                    <label>[% Translate("Actual Start Time") | html %]:</label>
                     <p class="Value">[% Data.ActualStartTime | Localize("TimeLong") %][% Data.EmptyActualStartTime | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("ActualStartTime") %]
 
 [% RenderBlockStart("ActualEndTime") %]
-                    <label>[% Translate("ActualEndTime") | html %]:</label>
+                    <label>[% Translate("Actual End Time") | html %]:</label>
                     <p class="Value">[% Data.ActualEndTime | Localize("TimeLong") %][% Data.EmptyActualEndTime | html %]</p>
                     <div class="Clear"></div>
 [% RenderBlockEnd("ActualEndTime") %]


### PR DESCRIPTION
Hi @mgruner and @UdoBretz
I have to propose some wording improvement, because now it is impossible to translate some strings. Some of them are differ from the ones in OTRS framework, some are in CamelCase format (the translator will not know whether he have to translate it or leave it untranslated), and the main problem is, that there are some sentences, which are marked as translatable word by word. If the target language uses different word order, it is impossible to create a correct sentence.
This is a big change of translatable strings. Please sync with Transifex after merging to give enough time for translators to finish it.