### PR TITLE
Solved issue in params check in StateTransitionDeleteAll

### DIFF
--- a/Kernel/System/ITSMChange/ITSMStateMachine.pm
+++ b/Kernel/System/ITSMChange/ITSMStateMachine.pm
@@ -319,7 +319,7 @@ sub StateTransitionDeleteAll {
     my ( $Self, %Param ) = @_;
 
     # check needed parameter
-    if ( $Param{Class} ) {
+    if ( ! $Param{Class} ) {
         $Kernel::OM->Get('Kernel::System::Log')->Log(
             Priority => 'error',
             Message  => 'Need Class!',


### PR DESCRIPTION
StateTransitionDeleteAll was throwing error when $Param{Class} was present. Obviously, it should throw error when it WASN'T present. Also, I'm sure it's not tested and I don't think this function has ever been used by anyone.