### PR TITLE
Marked Breadcrumb as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AdminITSMChangeNotification.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminITSMChangeNotification.tt
@@ -20,11 +20,11 @@
 
     IF Data.Action == 'Add';
         BreadcrumbPath.push({
-            Name => 'Add Notification Rule',
+            Name => Translate('Add Notification Rule'),
         });
     ELSIF Data.Action == 'Change';
         BreadcrumbPath.push({
-            Name => 'Edit Notification Rule',
+            Name => Translate('Edit Notification Rule'),
         });
     END;
 


### PR DESCRIPTION
Hello @UdoBretz 
These breadcrumb titles are not marked as translatable.